### PR TITLE
Inherit fife.Exception from python's (Base)Exception

### DIFF
--- a/engine/swigwrappers/python/fife.i.templ
+++ b/engine/swigwrappers/python/fife.i.templ
@@ -134,6 +134,8 @@ print s\n\
 	}
 %}
 
+%exceptionclass FIFE::Exception;
+
 %feature("director:except") {
 	if ($$error != NULL) {
 		handleDirectorException();


### PR DESCRIPTION
As outlined in [PEP-352](http://www.python.org/dev/peps/pep-0352/), exceptions should be properly derived from a
base exception class. With `%exceptionclass` SWIG will generate this:

``` py
    class Exception(Exception):
```

in fife.py where before it generated this:

``` py
    class Exception:
```

The SWIG default is to support python versions earlier than 2.5 (where
BaseException was introduced), so it uses python.Exception here.
With Python 2.5, Exception was made a subclass of the newly introduced
BaseException, so this still does the right thing and I'm not concerned.
