### PR TITLE
Convince SWIG that Color.r (g, b, a) should be a python property

### DIFF
--- a/engine/core/video/video.i
+++ b/engine/core/video/video.i
@@ -33,6 +33,8 @@
 #include "util/base/exception.h"
 %}
 
+%include <attribute.i>
+
 %include "util/base/utilbase.i"
 %include "util/structures/utilstructures.i"
 %include "util/resource/resource.i"
@@ -44,6 +46,11 @@ namespace FIFE {
 namespace std {
 	%template(ScreenModeVector) std::vector<FIFE::ScreenMode>;
 }
+
+%attribute(FIFE::Color, uint8_t, r, getR, setR);
+%attribute(FIFE::Color, uint8_t, g, getG, setG);
+%attribute(FIFE::Color, uint8_t, b, getB, setB);
+%attribute(FIFE::Color, uint8_t, a, getAlpha, setAlpha);
 
 namespace FIFE {
 	class Point;


### PR DESCRIPTION
While `%attribute` is not mentioned in SWIG documentation, there is
https://github.com/swig/swig/blob/master/Lib/typemaps/attribute.swg

Instead of using the old getR(), getG() getters and setB(128) etc., you
now can do:

``` py
    >>> c = fife.Color(80, 0, 255, 128)
    >>> print c.r  # This replaces getR()
    80
    >>> c.g = 64   # This replaces setG(64)
    >>> print c.g  # This replaces getG()
    64
```

and so on. Note that the `Alpha` setters are rather likely to become
deprecated soon in favor of `getA()` and `setA()`, so the name of the
associated python property also is `a` over `alpha`:

``` py
    >>> print c.a  # This replaces getAlpha()
    128
    >>> c.a = 255  # This replaces setAlpha(255)
```

**Thanks to @prock-fife for making this work!**
