### PR TITLE
Some pretty brute-force compiler warning fixes

### DIFF
--- a/engine/core/video/image.cpp
+++ b/engine/core/video/image.cpp
@@ -318,23 +318,34 @@ namespace FIFE {
 		if(this->isSharedImage()) {
 			Rect const& rect = this->getSubImageRect();
 			SDL_Rect dstrect = {
-				rect.x + xoffset, rect.y + yoffset,
+				static_cast<Sint16>(rect.x + xoffset),
+				static_cast<Sint16>(rect.y + yoffset),
 				static_cast<Uint16>(srcimg->getWidth()),
 				static_cast<Uint16>(srcimg->getHeight()) };
 			if(srcimg->isSharedImage()) {
 				Rect const& rect = srcimg->getSubImageRect();
-				SDL_Rect srcrect = { rect.x, rect.y, rect.w, rect.h };
+				SDL_Rect srcrect = {
+					static_cast<Sint16>(rect.x),
+					static_cast<Sint16>(rect.y),
+					static_cast<Uint16>(rect.w),
+					static_cast<Uint16>(rect.h) };
 				SDL_BlitSurface(srcimg->m_surface, &srcrect, m_surface, &dstrect);
 			} else {
 				SDL_BlitSurface(srcimg->m_surface, NULL, m_surface, &dstrect);
 			}
 		} else {
-			SDL_Rect dstrect = { xoffset, yoffset,
+			SDL_Rect dstrect = {
+				static_cast<Sint16>(xoffset),
+				static_cast<Sint16>(yoffset),
 				static_cast<Uint16>(srcimg->getWidth()),
 				static_cast<Uint16>(srcimg->getHeight()) };
 			if(srcimg->isSharedImage()) {
 				Rect const& rect = srcimg->getSubImageRect();
-				SDL_Rect srcrect = { rect.x, rect.y, rect.w, rect.h };
+				SDL_Rect srcrect = {
+					static_cast<Sint16>(rect.x),
+					static_cast<Sint16>(rect.y),
+					static_cast<Uint16>(rect.w),
+					static_cast<Uint16>(rect.h) };
 				SDL_BlitSurface(srcimg->m_surface, &srcrect, m_surface, &dstrect);
 			} else {
 				SDL_BlitSurface(srcimg->m_surface, NULL, m_surface, &dstrect);

--- a/engine/core/video/sdl/sdlimage.cpp
+++ b/engine/core/video/sdl/sdlimage.cpp
@@ -682,7 +682,11 @@ namespace FIFE {
 			src_surface->format->Bmask, src_surface->format->Amask);
 
 		SDL_SetAlpha(src_surface, 0, 0);
-		SDL_Rect srcrect = { region.x, region.y, region.w, region.h };
+		SDL_Rect srcrect = {
+			static_cast<Sint16>(region.x),
+			static_cast<Sint16>(region.y),
+			static_cast<Uint16>(region.w),
+			static_cast<Uint16>(region.h) };
 		SDL_BlitSurface(src_surface, &srcrect, surface, NULL);
 		SDL_SetAlpha(src_surface, SDL_SRCALPHA, 0);
 


### PR DESCRIPTION
```
warning:
  narrowing conversion of ‘rect.FIFE::RectType<int>::w’ from
  ‘const int’ to ‘Uint16 {aka short unsigned int}’ inside { } is
  ill-formed in C++11 [-Wnarrowing]
```

Closes #789
