### PR TITLE
[Dont merge!] Add files to be cleaned for default target 

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -473,11 +473,11 @@ env.Append(BUILDERS = {'BuildDocs': doc_builder})
 Alias('docs', env.BuildDocs('docs', os.path.join('doc', 'doxygen', 'doxyfile')))
 
 #**************************************************************************
-#Create a distclean target
+# Delete additional files for default target 'fife-python'
 #**************************************************************************
-env.Clean("distclean",
+env.Clean('fife-python',
 		[
-		 '.sconsign.dblite',
+		 '.sconsign.tmp',
 		 os.path.join('build','.sconf_temp'),
 		 os.path.join('engine','swigwrappers', 'python', 'fife_wrap.cc'),
 		 os.path.join('engine','swigwrappers', 'python', 'fife_wrap.h'),


### PR DESCRIPTION
instead of distclean argument. Also fixes outdated filename
.sconsign.dblite is now .sconsign.tmp. See #852 for reason to make these changes.