### PR TITLE
Fixed the problem that image offsets were lost by image free() (again)

### DIFF
--- a/engine/core/video/opengl/glimage.cpp
+++ b/engine/core/video/opengl/glimage.cpp
@@ -571,7 +571,12 @@ namespace FIFE {
 	}
 
 	void GLImage::free() {
+		// save the image offsets
+		int32_t xshift = m_xshift;
+		int32_t yshift = m_yshift;
 		setSurface(NULL);
+		m_xshift = xshift;
+		m_yshift = yshift;
 		m_state = IResource::RES_NOT_LOADED;
 	}
 

--- a/engine/core/video/sdl/sdlimage.cpp
+++ b/engine/core/video/sdl/sdlimage.cpp
@@ -725,7 +725,12 @@ namespace FIFE {
 	}
 
 	void SDLImage::free() {
+		// save the image offsets
+		int32_t xshift = m_xshift;
+		int32_t yshift = m_yshift;
 		setSurface(NULL);
+		m_xshift = xshift;
+		m_yshift = yshift;
 		m_state = IResource::RES_NOT_LOADED;
 	}
 }


### PR DESCRIPTION
The previous fix only changed Image, but not GLImage and SDLImage