### PR TITLE
Start position for animations

### DIFF
--- a/engine/core/loaders/native/map/objectloader.cpp
+++ b/engine/core/loaders/native/map/objectloader.cpp
@@ -406,13 +406,17 @@ namespace FIFE {
                                 int animYoffset = 0;
                                 int frameWidth = 0;
                                 int frameHeight = 0;
-
+                                int xstart = 0;
+                                int ystart = 0;
+                                
                                 animElement->QueryValueAttribute("width", &frameWidth);
                                 animElement->QueryValueAttribute("height", &frameHeight);
                                 animElement->QueryValueAttribute("frames", &animFrames);
                                 animElement->QueryValueAttribute("delay", &animDelay);
                                 animElement->QueryValueAttribute("x_offset", &animXoffset);
-								animElement->QueryValueAttribute("y_offset", &animYoffset);
+                                animElement->QueryValueAttribute("y_offset", &animYoffset);
+                                animElement->QueryValueAttribute("x_start", &xstart);
+                                animElement->QueryValueAttribute("y_start", &ystart);
                                 int nDir = 0;
 
                                 for (TiXmlElement* dirElement = animElement->FirstChildElement("direction");
@@ -464,7 +468,7 @@ namespace FIFE {
                                             if (!m_imageManager->exists(frameId)) {
 												framePtr = m_imageManager->create(frameId);
                                            		Rect region(
-													frameWidth * iframe, frameHeight * nDir, frameWidth, frameHeight
+													xstart + (frameWidth * iframe), ystart + (frameHeight * nDir), frameWidth, frameHeight
 												);
 												framePtr->useSharedImage(atlasImgPtr, region);
 												framePtr->setXShift(xoffset);

--- a/engine/core/loaders/native/map/objectloader.cpp
+++ b/engine/core/loaders/native/map/objectloader.cpp
@@ -406,8 +406,8 @@ namespace FIFE {
                                 int animYoffset = 0;
                                 int frameWidth = 0;
                                 int frameHeight = 0;
-                                int xstart = 0;
-                                int ystart = 0;
+                                int xpos = 0;
+                                int ypos = 0;
                                 
                                 animElement->QueryValueAttribute("width", &frameWidth);
                                 animElement->QueryValueAttribute("height", &frameHeight);
@@ -415,8 +415,8 @@ namespace FIFE {
                                 animElement->QueryValueAttribute("delay", &animDelay);
                                 animElement->QueryValueAttribute("x_offset", &animXoffset);
                                 animElement->QueryValueAttribute("y_offset", &animYoffset);
-                                animElement->QueryValueAttribute("x_start", &xstart);
-                                animElement->QueryValueAttribute("y_start", &ystart);
+                                animElement->QueryValueAttribute("x_pos", &xpos);
+                                animElement->QueryValueAttribute("y_pos", &ypos);
                                 int nDir = 0;
 
                                 for (TiXmlElement* dirElement = animElement->FirstChildElement("direction");
@@ -468,7 +468,7 @@ namespace FIFE {
                                             if (!m_imageManager->exists(frameId)) {
 												framePtr = m_imageManager->create(frameId);
                                            		Rect region(
-													xstart + (frameWidth * iframe), ystart + (frameHeight * nDir), frameWidth, frameHeight
+													xpos + (frameWidth * iframe), ypos + (frameHeight * nDir), frameWidth, frameHeight
 												);
 												framePtr->useSharedImage(atlasImgPtr, region);
 												framePtr->setXShift(xoffset);


### PR DESCRIPTION
These changes add an optional "x_pos" and "y_pos" attribute to "animation" tags in an object definition. This allows for several actions in a single image.

Example:

```
<?fife type="object"?>
<object blocking="1" id="player" namespace="FIFE" static="0">
	<action id="walk">
		<animation atlas="player.png" y_pos="512" x_pos="64" height="64" width="64" y_offset="-28">
			<direction delay="100" dir="90" frames="8"/>
			<direction delay="100" dir="180" frames="8"/>
			<direction delay="100" dir="270" frames="8"/>
			<direction delay="100" dir="0" frames="8"/>
		</animation>
	</action>
</object>
```