### PR TITLE
forcing bool values for some setting

### DIFF
--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -361,6 +361,12 @@ class Setting(object):
 						self._settingsFromFile[module][name] = e_value
 					elif name == "MouseAcceleration":
 						self._settingsFromFile[module][name] = e_value
+
+					elif name in ("SDLRemoveFakeAlpha", "LogToPrompt", "LogToFile"):
+						if type(e_value) != bool:
+							self._logger.log_warn("Use of type int for %s is deprecated. Use bool instead!"%name)
+						self._settingsFromFile[module][name] = bool(e_value)
+
 					else:
 
 						if isinstance(self._settingsFromFile[module][name],list) == True or isinstance(self._settingsFromFile[module][name],dict) == True:

--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -364,7 +364,11 @@ class Setting(object):
 
 					elif name in ("SDLRemoveFakeAlpha", "LogToPrompt", "LogToFile"):
 						if type(e_value) == int:
-							e_value = (False, True)[e_value]
+							try:
+								e_value = (False, True)[e_value]
+							except IndexError:
+								self._logger.log_warn("Invalid int-value for %s. Defaulted to False!"%name)
+								e_value = False
 							self._logger.log_warn("Use of type int for %s is deprecated. Use bool instead!"%name)
 						self._settingsFromFile[module][name] = e_value
 

--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -363,9 +363,10 @@ class Setting(object):
 						self._settingsFromFile[module][name] = e_value
 
 					elif name in ("SDLRemoveFakeAlpha", "LogToPrompt", "LogToFile"):
-						if type(e_value) != bool:
+						if type(e_value) == int:
+							e_value = (False, True)[e_value]
 							self._logger.log_warn("Use of type int for %s is deprecated. Use bool instead!"%name)
-						self._settingsFromFile[module][name] = bool(e_value)
+						self._settingsFromFile[module][name] = e_value
 
 					else:
 


### PR DESCRIPTION
found some old files that still contain some settings as int
that are now required to be boolean by the swig-bindings.
extended the settings-script to convert those values to bool
and print a deprecation warning to the log whenever it discovers
an unsupported type.