### PR TITLE
Add an option to setup.py to set package version from command line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,23 @@
 # ####################################################################
 
 
-from distutils.core import setup
+from distutils.core import setup, Command
 import os, sys
+
+
+class SetMetadataCommand(Command):
+    description = 'set metadata to be used by the following commands'
+    user_options = [
+        ('version=', None, 'set the package version'),
+    ]
+    def initialize_options(self):
+        self.version = None
+    def finalize_options(self):
+        return
+    def run(self):
+        print "setting package version to {}".format(self.version)
+        self.distribution.metadata.version = self.version
+
 
 if sys.platform == 'win32':
 	pkg_data = {'fife': ['*.pyd','*.dll'] }
@@ -40,6 +55,7 @@ setup(name='fife',
       package_dir = { '': os.path.join('engine','python') },
       package_data = pkg_data,
       data_files = [(os.path.join('lib','site-packages', 'fife'),['AUTHORS','CHANGES', 'LICENSE.md' ,'README.md'])],
-      license = 'GNU Lesser General Public License, version 2.1'
+      license = 'GNU Lesser General Public License, version 2.1',
+      cmdclass = { 'set_metadata': SetMetadataCommand }
       )
 


### PR DESCRIPTION
For example:
python setup.py set_metadata --version=0.4.1 bdist_wininst

Issue #908 