### PR TITLE
Fixed memory leak from 594852b caused by eventmanager

### DIFF
--- a/engine/core/controller/engine.cpp
+++ b/engine/core/controller/engine.cpp
@@ -323,7 +323,7 @@ namespace FIFE {
 
 		delete m_imagemanager;
 		delete m_soundclipmanager;
-//		delete m_eventmanager;
+		delete m_eventmanager;
 
 		// properly remove all the renderers created during init
 		delete m_offrenderer;


### PR DESCRIPTION
This delete was commented out back in 2011 and caused a small memory leak when the engine was destroyed. I don't know if the destructor for EventManager should be edited, but my memory leak detection tool doesn't detect leaks from it.