### PR TITLE
Load default settings if settings file has no FIFE module

### DIFF
--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -157,6 +157,11 @@ class Setting(object):
 
 		self.initSerializer()
 
+		# if there's no FIFE module assume the settings file is broken
+		# and replace with default settings file
+		if "FIFE" not in self._serializer.getModuleNameList():
+			self.setDefaults()
+
 		# Get all modules and initialize reading of them from xml file as false
 		self._allModules = self._serializer.getModuleNameList()
 		# print("All Module Names:",self._allModules)


### PR DESCRIPTION
This should prevent errors like the one in Issue #959