### PR TITLE
Don't allow "in-source-tree" build directory for older cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,17 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
                        Before that, cleanup:\nrm -rf CMakeCache.txt CMakeFiles")
 endif()
 
+# Do not allow the build directory to be in the source directory for older
+# versions of cmake.
+if (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_BINARY_DIR} MATCHES "^${CMAKE_SOURCE_DIR}")
+  message(FATAL_ERROR "# Please chose a different build directory.\n
+    In cmake versions < 3 SWIG does not work well when the build directory is
+    placed inside the source directory.
+    Use something like this:\n
+        mkdir ../_build; cd ../_build; cmake ../fifengine\n
+    You can remove your current build folder.")
+endif()
+
 # Disable in-source builds and modifications to the source tree.
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)


### PR DESCRIPTION
In older versions (<3.0) of CMake, the UseSWIG.cmake module does some
matching against the SOURCE_DIR and then against the BINARY_DIR. If the
BIN_DIR has the SRC_DIR as a parent, the paths of certain files in the
generated Makefile might end up wrong and the files cannot be compiled.

With this patch, cmake does not allow the BINARY_DIR to have the
SOURCE_DIR as a parent for CMake versions < 3. Instead, it shows a hint
and exits.