### PR TITLE
Fix Location::getLayerCoordinates() on hex grids

### DIFF
--- a/engine/core/model/metamodel/grids/cellgrid.h
+++ b/engine/core/model/metamodel/grids/cellgrid.h
@@ -110,6 +110,11 @@ namespace FIFE {
 		 */
 		virtual ExactModelCoordinate toExactLayerCoordinates(const ExactModelCoordinate& map_coord) = 0;
 
+		/** Transforms given point from exact layer coordinates to cell precision layer coordinates
+		 *  @return point in layer coordinates
+		 */
+		virtual ModelCoordinate toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords) = 0;
+
 		/** Fills given point vector with vertices from selected cell
 		 *  @param vtx vertices for given cell
 		 *  @param cell cell to get vertices from

--- a/engine/core/model/metamodel/grids/cellgrids.i
+++ b/engine/core/model/metamodel/grids/cellgrids.i
@@ -50,6 +50,7 @@ namespace FIFE {
 		virtual ExactModelCoordinate toMapCoordinates(const ExactModelCoordinate& layer_coords) = 0;
 		virtual ModelCoordinate toLayerCoordinates(const ExactModelCoordinate& map_coord) = 0;
 		virtual ExactModelCoordinate toExactLayerCoordinates(const ExactModelCoordinate& map_coord) = 0;
+		virtual ModelCoordinate toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords) = 0;
 		virtual void getVertices(std::vector<ExactModelCoordinate>& vtx, const ModelCoordinate& cell) = 0;
 		virtual std::vector<ModelCoordinate> getCoordinatesInLine(const ModelCoordinate& start, const ModelCoordinate& end) = 0;
 		void setXShift(const double& xshift);
@@ -81,6 +82,7 @@ namespace FIFE {
 		ExactModelCoordinate toMapCoordinates(const ExactModelCoordinate& layer_coords);
 		ModelCoordinate toLayerCoordinates(const ExactModelCoordinate& map_coord);
 		ExactModelCoordinate toExactLayerCoordinates(const ExactModelCoordinate& map_coord);
+		ModelCoordinate toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords);
 		void getVertices(std::vector<ExactModelCoordinate>& vtx, const ModelCoordinate& cell);
 		std::vector<ModelCoordinate> getCoordinatesInLine(const ModelCoordinate& start, const ModelCoordinate& end);
 	};
@@ -98,6 +100,7 @@ namespace FIFE {
 		ExactModelCoordinate toMapCoordinates(const ExactModelCoordinate& layer_coords);
 		ModelCoordinate toLayerCoordinates(const ExactModelCoordinate& map_coord);
 		ExactModelCoordinate toExactLayerCoordinates(const ExactModelCoordinate& map_coord);
+		ModelCoordinate toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords);
 		void getVertices(std::vector<ExactModelCoordinate>& vtx, const ModelCoordinate& cell);
 		std::vector<ModelCoordinate> getCoordinatesInLine(const ModelCoordinate& start, const ModelCoordinate& end);
 	};

--- a/engine/core/model/metamodel/grids/hexgrid.cpp
+++ b/engine/core/model/metamodel/grids/hexgrid.cpp
@@ -138,6 +138,19 @@ namespace FIFE {
 		FL_DBG(_log, LMsg("==============\nConverting map coords ") << map_coord << " to int32_t layer coords...");
 		ExactModelCoordinate elc = m_inverse_matrix * map_coord;
 		elc.y *= VERTICAL_MULTIP_INV;
+		return toLayerCoordinatesHelper(elc);
+	}
+
+	ModelCoordinate HexGrid::toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords) {
+		ExactModelCoordinate elc = exact_layer_coords;
+		elc.x += getXZigzagOffset(elc.y);
+		return toLayerCoordinatesHelper(elc);
+	}
+
+	ModelCoordinate HexGrid::toLayerCoordinatesHelper(const ExactModelCoordinate& coords) {
+		// this helper method takes exact layer coordinates with zigzag removed
+		// and converts them to layer coordinates
+		ExactModelCoordinate elc = coords;
 
 		// approximate conversion using squares instead of hexes
 		if( static_cast<int32_t>(round(elc.y)) & 1 )

--- a/engine/core/model/metamodel/grids/hexgrid.h
+++ b/engine/core/model/metamodel/grids/hexgrid.h
@@ -49,6 +49,7 @@ namespace FIFE {
 		ExactModelCoordinate toMapCoordinates(const ExactModelCoordinate& layer_coords);
 		ModelCoordinate toLayerCoordinates(const ExactModelCoordinate& map_coord);
 		ExactModelCoordinate toExactLayerCoordinates(const ExactModelCoordinate& map_coord);
+		ModelCoordinate toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords);
 		void getVertices(std::vector<ExactModelCoordinate>& vtx, const ModelCoordinate& cell);
 		std::vector<ModelCoordinate> toMultiCoordinates(const ModelCoordinate& position, const std::vector<ModelCoordinate>& orig, bool reverse);
 		std::vector<ModelCoordinate> getCoordinatesInLine(const ModelCoordinate& start, const ModelCoordinate& end);
@@ -56,6 +57,7 @@ namespace FIFE {
 
 	private:
 		double getXZigzagOffset(double y);
+		ModelCoordinate toLayerCoordinatesHelper(const ExactModelCoordinate& coords);
 	};
 }
 

--- a/engine/core/model/metamodel/grids/squaregrid.cpp
+++ b/engine/core/model/metamodel/grids/squaregrid.cpp
@@ -104,8 +104,11 @@ namespace FIFE {
 
 	ModelCoordinate SquareGrid::toLayerCoordinates(const ExactModelCoordinate& map_coord) {
 		ExactModelCoordinate dblpt = toExactLayerCoordinates(map_coord);
-		ModelCoordinate result(round(dblpt.x), round(dblpt.y), round(dblpt.z));
+		return toLayerCoordinatesFromExactLayerCoordinates(dblpt);
+	}
 
+	ModelCoordinate SquareGrid::toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords) {
+		ModelCoordinate result(round(exact_layer_coords.x), round(exact_layer_coords.y), round(exact_layer_coords.z));
 		return result;
 	}
 

--- a/engine/core/model/metamodel/grids/squaregrid.h
+++ b/engine/core/model/metamodel/grids/squaregrid.h
@@ -49,6 +49,7 @@ namespace FIFE {
 		ExactModelCoordinate toMapCoordinates(const ExactModelCoordinate& layer_coords);
 		ModelCoordinate toLayerCoordinates(const ExactModelCoordinate& map_coord);
 		ExactModelCoordinate toExactLayerCoordinates(const ExactModelCoordinate& map_coord);
+		ModelCoordinate toLayerCoordinatesFromExactLayerCoordinates(const ExactModelCoordinate& exact_layer_coords);
 		void getVertices(std::vector<ExactModelCoordinate>& vtx, const ModelCoordinate& cell);
 		std::vector<ModelCoordinate> toMultiCoordinates(const ModelCoordinate& position, const std::vector<ModelCoordinate>& orig, bool reverse);
 		std::vector<ModelCoordinate> getCoordinatesInLine(const ModelCoordinate& start, const ModelCoordinate& end);

--- a/engine/core/model/structures/location.cpp
+++ b/engine/core/model/structures/location.cpp
@@ -111,7 +111,7 @@ namespace FIFE {
 	}
 	
 	ModelCoordinate Location::getLayerCoordinates() const {
-		return ModelCoordinate(doublePt2intPt(m_exact_layer_coords));
+		return m_layer->getCellGrid()->toLayerCoordinatesFromExactLayerCoordinates(m_exact_layer_coords);
 	}
 	
 	ExactModelCoordinate Location::getMapCoordinates() const {


### PR DESCRIPTION
Location::getLayerCoordinates() converts from ExactLayerCoordinates to LayerCoordinates by naive conversion from float to int. This works fine on square grids, but can return the wrong coordinates when close to cell edge on hex grids.

The fix is to use the CellGrid methods instead. It's a two-step conversion (ExactLayer to Map to Layer). It can probably be optimized by removing the intermediate step, but I think it would require an additional CellGrid method.