### PR TITLE
Change the default settings.xml location

### DIFF
--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -81,7 +81,8 @@ class Setting(object):
 
 		if self._settings_file == "":
 			self._settings_file = "settings.xml"
-			self._appdata = getUserDataDirectory("fife", self._app_name)
+			self._appdata = "."
+			#self._appdata = getUserDataDirectory("fife", self._app_name)
 		else:
 			self._appdata = os.path.dirname(self._settings_file)
 			self._settings_file = os.path.basename(self._settings_file)


### PR DESCRIPTION
Issue fifengine/fifengine-demos#8

Before: ~/.fife/appname/ (or equivalent on other OS)
Now: . (the application's working directory)

Left the old default commented out for reference.