### PR TITLE
pychan: Remove Icon from manager on source load failure

### DIFF
--- a/engine/python/fife/extensions/pychan/widgets/icon.py
+++ b/engine/python/fife/extensions/pychan/widgets/icon.py
@@ -26,6 +26,7 @@ from fife import fifechan
 from fife.extensions.pychan.attrs import Attr, BoolAttr
 from fife.extensions.pychan.properties import ImageProperty
 
+from common import get_manager
 from widget import Widget
 
 
@@ -88,7 +89,11 @@ class Icon(Widget):
 
 		if scale is not None: self.scale = scale
 
-		self.image = image
+		try:
+			self.image = image
+		except Exception:
+			get_manager().removeWidget(self)
+			raise
 		
 		#if the size parameter is specified set it (again) to override
 		#the icons size.


### PR DESCRIPTION
When creating an `Icon` with an invalid file path, the `Icon` object
first calls its parent's `__init__()` and then trys to load the image
source.  Loading the image might end up in e.g. `fife.NotFound`, but the
parent's `__init__()` already added the new `Icon` instance to the
manager. So while the code creating the `Icon` will never see an
instance of it and can never call `hide()` to remove it, the manager
still thinks that there's an instance available.

This commit changes to code to remove the `Icon` from the manager for
any occuring exception and then re-raise the exception.