### PR TITLE
Add an axial coordinate system for hex grid (#732)

### DIFF
--- a/engine/core/controller/engine.cpp
+++ b/engine/core/controller/engine.cpp
@@ -305,7 +305,8 @@ namespace FIFE {
 		m_model->adoptPather(new RoutePather());
 		FL_LOG(_log, "Adding grid prototypes to model");
 		m_model->adoptCellGrid(new SquareGrid());
-		m_model->adoptCellGrid(new HexGrid());
+		m_model->adoptCellGrid(new HexGrid(false));
+		m_model->adoptCellGrid(new HexGrid(true));
 
 		m_cursor = new Cursor(m_renderbackend);
 		FL_LOG(_log, "Engine initialized");

--- a/engine/core/model/metamodel/grids/cellgrids.i
+++ b/engine/core/model/metamodel/grids/cellgrids.i
@@ -71,7 +71,7 @@ namespace FIFE {
 
 	class HexGrid: public CellGrid {
 	public:
-		HexGrid();
+		HexGrid(bool axial = false);
 		virtual ~HexGrid();
 
 		bool isAccessible(const ModelCoordinate& curpos, const ModelCoordinate& target);

--- a/engine/core/model/metamodel/grids/hexgrid.cpp
+++ b/engine/core/model/metamodel/grids/hexgrid.cpp
@@ -44,8 +44,9 @@ namespace FIFE {
 	static const double VERTICAL_MULTIP_INV = 1 / VERTICAL_MULTIP;
 	static const double HEX_EDGE_GRADIENT = 1 / Mathd::Sqrt(3);
 
-	HexGrid::HexGrid():
-		CellGrid() {
+	HexGrid::HexGrid(bool axial):
+		CellGrid(),
+		m_axial(axial) {
 		FL_DBG(_log, "Constructing new HexGrid");
 		FL_DBG(_log, LMsg("HEX_WIDTH ") << HEX_WIDTH);
 		FL_DBG(_log, LMsg("HEX_TO_EDGE ") << HEX_TO_EDGE);
@@ -55,7 +56,7 @@ namespace FIFE {
 	}
 
 	CellGrid* HexGrid::clone() {
-		HexGrid* nGrid = new HexGrid();
+		HexGrid* nGrid = new HexGrid(m_axial);
 		nGrid->setRotation(m_rotation);
 		nGrid->setXScale(m_xscale);
 		nGrid->setYScale(m_yscale);
@@ -75,11 +76,16 @@ namespace FIFE {
 		int32_t y = target.y-curpos.y;
 
 		if (ABS(x) <= 1 && ABS(y) <= 1) {
-			if (y == 0) {
-				return true;
-			} else if (curpos.y & 1) {
-				if (x >= 0) return true;
-			} else if (x <= 0) return true;
+			if (m_axial) {
+				if (y == 0 || x == 0 || x == -y)
+					return true;
+			} else {
+				if (y == 0) {
+					return true;
+				} else if (curpos.y & 1) {
+					if (x >= 0) return true;
+				} else if (x <= 0) return true;
+			}
         }
 		return false;
 	}
@@ -96,25 +102,39 @@ namespace FIFE {
 	}
 
 	const std::string& HexGrid::getType() const {
-		static std::string type("hexagonal");
-		return type;
+		if (m_axial) {
+			static std::string type("hexagonal_axial");
+			return type;
+		} else {
+			static std::string type("hexagonal");
+			return type;
+		}
 	}
 
 	const std::string& HexGrid::getName() const {
-		static std::string hexGrid("Hex Grid");
-		return hexGrid;
+		if (m_axial) {
+			static std::string hexGrid("Hex Grid (Axial)");
+			return hexGrid;
+		} else {
+			static std::string hexGrid("Hex Grid");
+			return hexGrid;
+		}
 	}
 
 	double HexGrid::getXZigzagOffset(double y) {
-		// each uneven row has shifted coordinate of 0.5 horizontally
-		// shift has to be gradual on vertical axis
-		double ay = ABS(y);
-		int32_t i_layer_y = static_cast<int32_t>(ay);
-		double offset = ay - static_cast<double>(i_layer_y);
-		if ((i_layer_y % 2) == 1) {
-			offset = 1 - offset;
+		if (m_axial) {
+			return HEX_TO_EDGE * y;
+		} else {
+			// each uneven row has shifted coordinate of 0.5 horizontally
+			// shift has to be gradual on vertical axis
+			double ay = ABS(y);
+			int32_t i_layer_y = static_cast<int32_t>(ay);
+			double offset = ay - static_cast<double>(i_layer_y);
+			if ((i_layer_y % 2) == 1) {
+				offset = 1 - offset;
+			}
+			return HEX_TO_EDGE * offset;
 		}
-		return HEX_TO_EDGE * offset;
 	}
 
 	ExactModelCoordinate HexGrid::toMapCoordinates(const ExactModelCoordinate& layer_coords) {
@@ -190,6 +210,13 @@ namespace FIFE {
 			y += ddy;
 		}
 
+		if (m_axial) {
+			if (y >= 0)
+				x -= y / 2;
+			else
+				x -= (y - 1) / 2;
+		}
+
 		return ModelCoordinate(x,y,z);
 	}
 
@@ -198,10 +225,15 @@ namespace FIFE {
 		vtx.clear();
 		double x = static_cast<double>(cell.x);
 		double y = static_cast<double>(cell.y);
-		double horiz_shift = 0;
-		if (cell.y % 2 != 0) {
-			horiz_shift = HEX_TO_EDGE;
-			FL_DBG(_log, "on uneven row");
+		double horiz_shift;
+		if (m_axial) {
+			horiz_shift = HEX_TO_EDGE * cell.y;
+		} else {
+			horiz_shift = 0;
+			if (cell.y % 2 != 0) {
+				horiz_shift = HEX_TO_EDGE;
+				FL_DBG(_log, "on uneven row");
+			}
 		}
 		double tx, ty;
 

--- a/engine/core/model/metamodel/grids/hexgrid.h
+++ b/engine/core/model/metamodel/grids/hexgrid.h
@@ -37,7 +37,7 @@
 namespace FIFE {
 	class HexGrid: public CellGrid {
 	public:
-		HexGrid();
+		HexGrid(bool axial = false);
 		virtual ~HexGrid();
 
 		bool isAccessible(const ModelCoordinate& curpos, const ModelCoordinate& target);
@@ -58,6 +58,8 @@ namespace FIFE {
 	private:
 		double getXZigzagOffset(double y);
 		ModelCoordinate toLayerCoordinatesHelper(const ExactModelCoordinate& coords);
+
+		bool m_axial;
 	};
 }
 


### PR DESCRIPTION
Using terminology from http://www.redblobgames.com/grids/hexagons/, the new system uses axial coordinates, while the old one uses offset coordinates. It can be used by specifying grid_type="hexagonal_axial" in the map file (the old one remains simply "hexagonal").

I've decided to reuse the existing class instead of making a new one, as there aren't that many changes between the two systems.