### PR TITLE
Change version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,30 @@ project (fifengine C CXX)
 set (FIFE_MAJOR_VERSION 0)
 set (FIFE_MINOR_VERSION 4)
 set (FIFE_PATCH_VERSION 1)
+set (FIFE_VERSION_SHORT ${FIFE_MAJOR_VERSION}.${FIFE_MINOR_VERSION}.${FIFE_PATCH_VERSION})
 
-set(FIFE_VERSION ${FIFE_MAJOR_VERSION}.${FIFE_MINOR_VERSION}.${FIFE_PATCH_VERSION})
+# get git commit hash, if source folder is a git repository
+find_file(GITDIR NAMES .git PATHS ${CMAKE_SOURCE_DIR} NO_DEFAULT_PATH)
+if(GITDIR)
+  execute_process(
+    COMMAND git rev-parse --short=7 HEAD
+    WORKING_DIRECTORY "@CMAKE_SOURCE_DIR@/.."
+    OUTPUT_VARIABLE GIT_COMMIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  set(FIFE_GIT_HASH ${GIT_COMMIT_HASH})
+else()
+  # not a git repo, possibly a source download
+  set(FIFE_GIT_HASH "")
+endif()
+
+if(GIT_COMMIT_HASH)
+  set(FIFE_VERSION ${FIFE_VERSION_SHORT}+build.${FIFE_GIT_HASH})
+else()
+  set(FIFE_VERSION ${FIFE_VERSION_SHORT})
+endif()
+
+message("Updating version.h with version information and git meta data.")
 
 configure_file (
   "${PROJECT_SOURCE_DIR}/engine/core/version.h.in"
@@ -68,8 +90,7 @@ if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
                        Before that, cleanup:\nrm -rf CMakeCache.txt CMakeFiles")
 endif()
 
-# Do not allow the build directory to be in the source directory for older
-# versions of cmake.
+# Do not allow the build directory to be in the source directory for older versions of cmake.
 if (${CMAKE_MAJOR_VERSION} EQUAL 2 AND ${CMAKE_BINARY_DIR} MATCHES "^${CMAKE_SOURCE_DIR}")
   message(FATAL_ERROR "# Please chose a different build directory.\n
     In cmake versions < 3 SWIG does not work well when the build directory is
@@ -746,15 +767,6 @@ if(fifechan)
   if(rend-grid)
     add_definitions(-DRENDER_GRID)
   endif(rend-grid)
-  if(use-githash)
-    execute_process(
-      COMMAND git rev-parse --short=8 HEAD
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_COMMIT_HASH
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    add_definitions(-DFIFE_GIT_HASH=${GIT_COMMIT_HASH})
-  endif(use-githash)
   include_directories(${FIFECHAN_INCLUDE_DIR})
   link_directories(${FIFECHAN_LIBRARIES})
   if(build-python)
@@ -933,6 +945,7 @@ if(build-library)
   include(GNUInstallDirs)
   install(TARGETS fife DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(FILES ${PROJECT_SOURCE_DIR}/engine/core/version.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/fife/core/)
+  
   MACRO(INSTALL_HEADERS_WITH_DIRECTORY HEADER_LIST)
   
       FOREACH(HEADER ${${HEADER_LIST}})

--- a/engine/core/version.h.in
+++ b/engine/core/version.h.in
@@ -31,44 +31,44 @@
  */
 
 #define FIFE_VERSION        "@FIFE_VERSION@"
-#define FIFE_VERSION_SHORT	"@FIFE_VERSION_SHORT@"
+#define FIFE_VERSION_SHORT  "@FIFE_VERSION_SHORT@"
 #define FIFE_MAJOR_VERSION  @FIFE_MAJOR_VERSION@
 #define FIFE_MINOR_VERSION  @FIFE_MINOR_VERSION@
 #define FIFE_PATCH_VERSION  @FIFE_PATCH_VERSION@
 #define FIFE_GIT_HASH       "@FIFE_GIT_HASH@"
 
-/** 
- *  All FIFE related code is in the "FIFE" namespace.  
+/**
+ *  All FIFE related code is in the "FIFE" namespace.
  *  The namespace "fcn" (fifechan) is used for our custom widgets.
  */
 namespace FIFE {
-	inline const char* getVersion() {
-		return FIFE_VERSION;
-	}
+    inline const char* getVersion() {
+        return FIFE_VERSION;
+    }
 
-	inline const char* getVersionShort() {
-		return FIFE_VERSION_SHORT;
-	}
+    inline const char* getVersionShort() {
+        return FIFE_VERSION_SHORT;
+    }
 
-	inline int getMajor() {
-		return FIFE_MAJOR_VERSION;
-	}
+    inline int getMajor() {
+        return FIFE_MAJOR_VERSION;
+    }
 
-	inline int getMinor() {
-		return FIFE_MINOR_VERSION;
-	}
+    inline int getMinor() {
+        return FIFE_MINOR_VERSION;
+    }
 
-	inline int getPatch() {
-		return FIFE_PATCH_VERSION;
-	}
+    inline int getPatch() {
+        return FIFE_PATCH_VERSION;
+    }
 
-	inline const char* getHash() {
-		return FIFE_GIT_HASH;
-	}
+    inline const char* getHash() {
+        return FIFE_GIT_HASH;
+    }
 
-	inline const int getVersionId() {		
-		return FIFE_MAJOR_VERSION * 10000 + FIFE_MINOR_VERSION * 100 + FIFE_PATCH_VERSION; // 3.2.1 = 30201
-	}
+    inline const int getVersionId() {
+        return FIFE_MAJOR_VERSION * 10000 + FIFE_MINOR_VERSION * 100 + FIFE_PATCH_VERSION; // 3.2.1 = 30201
+    }
 } //FIFE
 
 #endif //FIFE_VERSION_H

--- a/engine/core/version.h.in
+++ b/engine/core/version.h.in
@@ -22,72 +22,32 @@
 #ifndef FIFE_VERSION_H
 #define FIFE_VERSION_H
 
-/** 
- * These version numbers are updated as part of the release process for FIFE.
+/**
+ * These version numbers are updated as part of the release process.
+ *
+ * The file "version.h.in" is a template file with placeholder tokens.
+ * CMake replaces these tokens during the project configuration phase
+ * and creates the file "version.h", see CMakeLists.txt.
  */
-#ifndef FIFE_VERSION
-	#define FIFE_VERSION "@FIFE_VERSION@"
-#endif
 
-#ifndef FIFE_MAJOR_VERSION
-	#define FIFE_MAJOR_VERSION @FIFE_MAJOR_VERSION@
-#endif
-#ifndef FIFE_MINOR_VERSION
-	#define FIFE_MINOR_VERSION @FIFE_MINOR_VERSION@
-#endif
-#ifndef FIFE_PATCH_VERSION
-	#define FIFE_PATCH_VERSION @FIFE_PATCH_VERSION@
-#endif
-
-/***************************************************************************
- * Do not update anything below this line!
- ***************************************************************************/
-
-#define FIFE_STR(s)			# s
-#define FIFE_XSTR(s)		FIFE_STR(s)
-
-#define FIFE_DOT(a,b)		a.b
-#define FIFE_XDOT(a,b)		FIFE_DOT(a,b)
-
-#define FIFE_PLUS(a,b)		a+b
-#define FIFE_XPLUS(a,b)		FIFE_PLUS(a,b)
-
-#define FIFE_MINUS(a,b)		a-b
-#define FIFE_XMINUS(a,b)	FIFE_MINUS(a,b)
-
-#ifdef FIFE_GIT_HASH
-	#ifndef FIFE_VERSION_STRING
-		#define FIFE_VERSION_STRING \
-			FIFE_XPLUS( \
-				FIFE_VERSION, \
-				FIFE_GIT_HASH \
-			)
-	#else
-		#undef FIFE_VERSION_STRING
-		#define FIFE_VERSION_STRING \
-			FIFE_XPLUS( \
-				FIFE_VERSION, \
-				FIFE_GIT_HASH \
-			)
-	#endif
-#else
-	#define FIFE_GIT_HASH ""
-#endif
-
-
-// This is an actual release
-#ifndef FIFE_VERSION_STRING
-	#define FIFE_VERSION_STRING FIFE_VERSION
-#endif
+#define FIFE_VERSION        "@FIFE_VERSION@"
+#define FIFE_VERSION_SHORT	"@FIFE_VERSION_SHORT@"
+#define FIFE_MAJOR_VERSION  @FIFE_MAJOR_VERSION@
+#define FIFE_MINOR_VERSION  @FIFE_MINOR_VERSION@
+#define FIFE_PATCH_VERSION  @FIFE_PATCH_VERSION@
+#define FIFE_GIT_HASH       "@FIFE_GIT_HASH@"
 
 /** 
- *  All FIFE related code is in this namespace.
- *  We currently only use one namespace for all our code with the exception of
- *  the gcn namespace which is used for our custom widgets.
+ *  All FIFE related code is in the "FIFE" namespace.  
+ *  The namespace "fcn" (fifechan) is used for our custom widgets.
  */
 namespace FIFE {
 	inline const char* getVersion() {
-		return FIFE_XSTR(FIFE_VERSION_STRING);
+		return FIFE_VERSION;
+	}
+
+	inline const char* getVersionShort() {
+		return FIFE_VERSION_SHORT;
 	}
 
 	inline int getMajor() {
@@ -103,21 +63,13 @@ namespace FIFE {
 	}
 
 	inline const char* getHash() {
-		return FIFE_XSTR(FIFE_GIT_HASH);
+		return FIFE_GIT_HASH;
+	}
+
+	inline const int getVersionId() {		
+		return FIFE_MAJOR_VERSION * 10000 + FIFE_MINOR_VERSION * 100 + FIFE_PATCH_VERSION; // 3.2.1 = 30201
 	}
 } //FIFE
-
-//cleanup
-#undef FIFE_STR
-#undef FIFE_XSTR
-#undef FIFE_DOT
-#undef FIFE_XDOT
-#undef FIFE_PLUS
-#undef FIFE_XPLUS
-#undef FIFE_MINUS
-#undef FIFE_XMINUS
-#undef FIFE_VERSION_STRING
-#undef FIFE_VERSION
 
 #endif //FIFE_VERSION_H
 

--- a/engine/core/version.i
+++ b/engine/core/version.i
@@ -24,11 +24,11 @@
 %}
 
 namespace FIFE {
-	inline const char* getVersion();
+    inline const char* getVersion();
     inline const char* getVersionShort();
-	inline int getMajor();
-	inline int getMinor();
-	inline int getPatch();
-	inline const char* getHash();
+    inline int getMajor();
+    inline int getMinor();
+    inline int getPatch();
+    inline const char* getHash();
     inline const int getVersionId();
 } //FIFE

--- a/engine/core/version.i
+++ b/engine/core/version.i
@@ -25,8 +25,10 @@
 
 namespace FIFE {
 	inline const char* getVersion();
+    inline const char* getVersionShort();
 	inline int getMajor();
 	inline int getMinor();
 	inline int getPatch();
 	inline const char* getHash();
+    inline const int getVersionId();
 } //FIFE


### PR DESCRIPTION
- remove all string expansion helpers
- version information and git metadata content is inserted by cmake
- added getVersionShort() = version without git hash
- added int getVersionId() = returns version 3.2.1 as 30201 (easier version comparison)