### PR TITLE
Add /bigobj compiler option for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,9 @@ if(WIN32 AND MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D \"WIN32_LEAN_AND_MEAN\"")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /D \"NOMINMAX\"")
 
+  # avoid "C1128: number of sections exceeded object file format limit: compile with /bigobj"
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj")
+
   # disable SAFESEH - to avoid "LNK2026: module unsafe" on "OpenAL32.lib"
   set(CMAKE_CXX_FLAGS           "${CMAKE_CXX_FLAGS} /D \"SAFESEH:NO\"")
   set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS} /SAFESEH:NO")


### PR DESCRIPTION
This avoids the compiler error "C1128: number of sections exceeded object file format limit: compile with /bigobj"