### PR TITLE
tweak CMAKE_SWIG_FLAGS by adding -O

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -875,7 +875,7 @@ if(build-python)
   find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
   include_directories(${PYTHON_INCLUDE_PATH})
 
-  set(CMAKE_SWIG_FLAGS -modern -modernargs -w511 -w473 -w404)
+  set(CMAKE_SWIG_FLAGS -O -w511 -w473 -w404)
 
   set_source_files_properties("${PROJECT_BINARY_DIR}/fife.i" PROPERTIES CPLUSPLUS ON)
   set(FIFE_SOURCES ${FIFE_CORE_SRC})


### PR DESCRIPTION
The compilation flag `-O` combines the following flags: `-modern -fastdispatch -nosafecstrings -fvirtual -noproxydel -fastproxy -fastinit -fastunpack -fastquery -modernargs -nobuildnone`. I found this in https://github.com/swig/swig/blob/73a5d6c187bb9dad7f17cc920774ec41d59968f0/Source/Modules/python.cxx#L165

I'm removing `-modern -modernargs`, because `-O` includes them.

Note for https://github.com/fifengine/fifengine/issues/712 : One might try reducing the build time by disabling compiler optimizations.