### PR TITLE
Native image cursor

### DIFF
--- a/engine/core/controller/engine.cpp
+++ b/engine/core/controller/engine.cpp
@@ -308,6 +308,7 @@ namespace FIFE {
 		m_model->adoptCellGrid(new HexGrid(true));
 
 		m_cursor = new Cursor(m_renderbackend);
+		m_cursor->setNativeImageCursorEnabled(m_settings.isNativeImageCursorEnabled());
 		FL_LOG(_log, "Engine initialized");
 	}
 

--- a/engine/core/controller/engine.i
+++ b/engine/core/controller/engine.i
@@ -116,7 +116,9 @@ namespace FIFE {
 		float getMouseSensitivity() const;
 		void setMouseAccelerationEnabled(bool acceleration);
 		bool isMouseAccelerationEnabled() const;
-		
+		void setNativeImageCursorEnabled(bool nativeimagecursor);
+		bool isNativeImageCursorEnabled() const;
+
 	private:
 		EngineSettings();
 	};	

--- a/engine/core/controller/enginesettings.cpp
+++ b/engine/core/controller/enginesettings.cpp
@@ -309,5 +309,13 @@ namespace FIFE {
 	bool EngineSettings::isMouseAccelerationEnabled() const {
 		return m_mouseacceleration;
 	}
+
+	void EngineSettings::setNativeImageCursorEnabled(bool nativeimagecursor) {
+		m_nativeimagecursor = nativeimagecursor;
+	}
+
+	bool EngineSettings::isNativeImageCursorEnabled() const {
+		return m_nativeimagecursor;
+	}
 }
 

--- a/engine/core/controller/enginesettings.h
+++ b/engine/core/controller/enginesettings.h
@@ -414,6 +414,10 @@ namespace FIFE {
 		 */
 		bool isMouseAccelerationEnabled() const;
 
+		void setNativeImageCursorEnabled(bool nativeimagecursor);
+
+		bool isNativeImageCursorEnabled() const;
+
 	private:
 		uint8_t m_bitsperpixel;
 		bool m_fullscreen;
@@ -449,6 +453,7 @@ namespace FIFE {
 		uint16_t m_framelimit;
 		float m_mousesensitivity;
 		bool m_mouseacceleration;
+		bool m_nativeimagecursor;
 	};
 
 }//FIFE

--- a/engine/core/controller/enginesettings.h
+++ b/engine/core/controller/enginesettings.h
@@ -414,8 +414,14 @@ namespace FIFE {
 		 */
 		bool isMouseAccelerationEnabled() const;
 
+		/** Enables or disables native image cursor.
+		 * @see Cursor::setNativeImageCursorEnabled()
+		 */
 		void setNativeImageCursorEnabled(bool nativeimagecursor);
 
+		/** Returns whether cursors set to an image or an animation are drawn natively.
+		 * @see Cursor::setNativeImageCursorEnabled()
+		 */
 		bool isNativeImageCursorEnabled() const;
 
 	private:

--- a/engine/core/loaders/native/map/animationloader.h
+++ b/engine/core/loaders/native/map/animationloader.h
@@ -35,6 +35,8 @@
 
 #include "ianimationloader.h"
 
+class TiXmlElement;
+
 namespace FIFE {
 
 	class VFS;

--- a/engine/core/loaders/native/map/ianimationloader.i
+++ b/engine/core/loaders/native/map/ianimationloader.i
@@ -21,6 +21,7 @@
 %module fife
 %{
 #include "loaders/native/map/ianimationloader.h"
+#include "loaders/native/map/animationloader.h"
 %}
 
 %include "video/video.i"
@@ -30,4 +31,5 @@ namespace FIFE {
 }
 
 %include "loaders/native/map/ianimationloader.h"
+%include "loaders/native/map/animationloader.h"
 

--- a/engine/core/modules.h
+++ b/engine/core/modules.h
@@ -64,6 +64,7 @@ enum logmodule_t {
 	LM_XML,
 	LM_EXCEPTION,
 	LM_SCRIPT,
+	LM_CURSOR,
 	LM_MODULE_MAX // sentinel
 };
 
@@ -100,7 +101,8 @@ enum logmodule_t {
 		  {LM_VIEWVIEW, LM_VIEW, "View::View"}, \
 		{LM_XML, LM_CORE, "XML"}, \
 		{LM_EXCEPTION, LM_CORE, "Exception"}, \
-		{LM_SCRIPT, LM_CORE, "Script"} \
+		{LM_SCRIPT, LM_CORE, "Script"}, \
+		{LM_CURSOR, LM_CORE, "Cursor"} \
 	};
 
 #endif

--- a/engine/core/video/cursor.cpp
+++ b/engine/core/video/cursor.cpp
@@ -42,7 +42,7 @@ namespace FIFE {
 	/** Logger to use for this source file.
 	 *  @relates Logger
 	 */
-	static Logger _log(LM_GUI); //@todo We should have a log module for cursor
+	static Logger _log(LM_CURSOR);
 
 	Cursor::Cursor(RenderBackend* renderbackend):
 		m_cursor_id(NC_ARROW),
@@ -243,7 +243,7 @@ namespace FIFE {
 		cursor_id = getNativeId(cursor_id);
 		SDL_Cursor* cursor = SDL_CreateSystemCursor(static_cast<SDL_SystemCursor>(cursor_id));
 		if (!cursor) {
-			FL_WARN(_log, "Cursor: No cursor matching cursor_id was found.");
+			FL_WARN(_log, "No cursor matching cursor_id was found.");
 			return;
 		}
 		m_native_cursor = cursor;

--- a/engine/core/video/cursor.cpp
+++ b/engine/core/video/cursor.cpp
@@ -288,6 +288,9 @@ namespace FIFE {
 			// we're already using this image
 			return true;
 		}
+		if (image->getState() == IResource::RES_NOT_LOADED) {
+			image->load();
+		}
 
 		// SDL only accepts whole surfaces here so if this image uses a shared surface
 		// we need to prepare a temporary surface with just the relevant part

--- a/engine/core/video/cursor.cpp
+++ b/engine/core/video/cursor.cpp
@@ -246,7 +246,10 @@ namespace FIFE {
 			FL_WARN(_log, "No cursor matching cursor_id was found.");
 			return;
 		}
-		m_native_cursor = cursor;
 		SDL_SetCursor(cursor);
+		if (m_native_cursor != NULL) {
+			SDL_FreeCursor(m_native_cursor);
+		}
+		m_native_cursor = cursor;
 	}
 }

--- a/engine/core/video/cursor.cpp
+++ b/engine/core/video/cursor.cpp
@@ -292,10 +292,11 @@ namespace FIFE {
 
 		SDL_Cursor* cursor = SDL_CreateColorCursor(temp_image->getSurface(), -image->getXShift(), -image->getYShift());
 		if (cursor == NULL) {
-			FL_WARN(_log, LMsg("SDL_CreateColorCursor: \"") << SDL_GetError();
+			FL_WARN(_log, LMsg("SDL_CreateColorCursor: \"") << SDL_GetError() << "\". Falling back to software cursor.");
 			if (image->isSharedImage()) {
 				ImageManager::instance()->remove(temp_image);
 			}
+			setNativeImageCursorEnabled(false);
 			return;
 		}
 		SDL_SetCursor(cursor);

--- a/engine/core/video/cursor.cpp
+++ b/engine/core/video/cursor.cpp
@@ -281,18 +281,25 @@ namespace FIFE {
 
 	void Cursor::setNativeImageCursor(ImagePtr image) {
 		if (image == m_native_cursor_image) {
+			// we're already using this image
 			return;
 		}
 
+		// SDL only accepts whole surfaces here so if this image uses a shared surface
+		// we need to prepare a temporary surface with just the relevant part
 		ImagePtr temp_image = image;
 		if (image->isSharedImage()) {
 			temp_image = ImageManager::instance()->create();
 			temp_image->copySubimage(0, 0, image);
 		}
 
-		SDL_Cursor* cursor = SDL_CreateColorCursor(temp_image->getSurface(), -image->getXShift(), -image->getYShift());
+		SDL_Cursor* cursor = SDL_CreateColorCursor(
+			temp_image->getSurface(),
+			-image->getXShift(),
+			-image->getYShift());
 		if (cursor == NULL) {
-			FL_WARN(_log, LMsg("SDL_CreateColorCursor: \"") << SDL_GetError() << "\". Falling back to software cursor.");
+			FL_WARN(_log, LMsg("SDL_CreateColorCursor: \"") << SDL_GetError() <<
+				"\". Falling back to software cursor.");
 			if (image->isSharedImage()) {
 				ImageManager::instance()->remove(temp_image);
 			}

--- a/engine/core/video/cursor.cpp
+++ b/engine/core/video/cursor.cpp
@@ -82,7 +82,9 @@ namespace FIFE {
 		m_cursor_type = CURSOR_IMAGE;
 
 		if (m_native_image_cursor_enabled) {
-			setNativeImageCursor(image);
+			if (!setNativeImageCursor(image)) {
+				return;
+			}
 			if (!SDL_ShowCursor(1)) {
 				SDL_PumpEvents();
 			}
@@ -102,7 +104,9 @@ namespace FIFE {
 		m_cursor_type = CURSOR_ANIMATION;
 
 		if (m_native_image_cursor_enabled) {
-			setNativeImageCursor(anim->getFrameByTimestamp(0));
+			if (!setNativeImageCursor(anim->getFrameByTimestamp(0))) {
+				return;
+			}
 			if (!SDL_ShowCursor(1)) {
 				SDL_PumpEvents();
 			}
@@ -279,10 +283,10 @@ namespace FIFE {
 		m_native_cursor = cursor;
 	}
 
-	void Cursor::setNativeImageCursor(ImagePtr image) {
+	bool Cursor::setNativeImageCursor(ImagePtr image) {
 		if (image == m_native_cursor_image) {
 			// we're already using this image
-			return;
+			return true;
 		}
 
 		// SDL only accepts whole surfaces here so if this image uses a shared surface
@@ -304,7 +308,7 @@ namespace FIFE {
 				ImageManager::instance()->remove(temp_image);
 			}
 			setNativeImageCursorEnabled(false);
-			return;
+			return false;
 		}
 		SDL_SetCursor(cursor);
 		m_native_cursor_image = image;
@@ -316,6 +320,7 @@ namespace FIFE {
 			SDL_FreeCursor(m_native_cursor);
 		}
 		m_native_cursor = cursor;
+		return true;
 	}
 
 	void Cursor::setNativeImageCursorEnabled(bool native_image_cursor_enabled) {

--- a/engine/core/video/cursor.h
+++ b/engine/core/video/cursor.h
@@ -187,8 +187,9 @@ namespace FIFE {
 
 		/** Sets the SDL cursor to the specified image.
 		 * Falls back to software cursor on failure.
+		 * @return false on error, true otherwise
 		 */
-		void setNativeImageCursor(ImagePtr image);
+		bool setNativeImageCursor(ImagePtr image);
 
 		/** To get some consistancy between platforms, this function checks
 		  * if cursor_id matches any of the values in NativeCursor, and

--- a/engine/core/video/cursor.h
+++ b/engine/core/video/cursor.h
@@ -166,11 +166,17 @@ namespace FIFE {
 		*/
 		void getPosition(int32_t* x, int32_t* y);
 
+		void setNativeImageCursorEnabled(bool native_image_cursor_enabled);
+
+		bool isNativeImageCursorEnabled() const;
+
 	protected:
 		/** Sets the cursor to a native type.
 		  * @param cursor_id One of the values in NativeCursor
 		  */
 		void setNativeCursor(uint32_t cursor_id);
+
+		void setNativeImageCursor(ImagePtr image);
 
 		/** To get some consistancy between platforms, this function checks
 		  * if cursor_id matches any of the values in NativeCursor, and
@@ -206,6 +212,8 @@ namespace FIFE {
 		TimeManager* m_timemanager;
 
 		bool m_invalidated;
+		bool m_native_image_cursor_enabled;
+		ImagePtr m_native_cursor_image;
 	};
 
 } //FIFE

--- a/engine/core/video/cursor.h
+++ b/engine/core/video/cursor.h
@@ -166,8 +166,17 @@ namespace FIFE {
 		*/
 		void getPosition(int32_t* x, int32_t* y);
 
+		/** Enables or disables the native image cursor feature.
+		 * If enabled, cursors set to an image or an animation will be set using SDL
+		 * and drawn by the native platform; otherwise they will be drawn by FIFE.
+		 * This setting has no effect on NativeCursor types which are always native
+		 * and on the drag cursor which is always drawn by FIFE.
+		 */
 		void setNativeImageCursorEnabled(bool native_image_cursor_enabled);
 
+		/** Returns whether cursors set to an image or an animation are drawn natively.
+		 * @see setNativeImageCursorEnabled()
+		 */
 		bool isNativeImageCursorEnabled() const;
 
 	protected:
@@ -176,6 +185,9 @@ namespace FIFE {
 		  */
 		void setNativeCursor(uint32_t cursor_id);
 
+		/** Sets the SDL cursor to the specified image.
+		 * Falls back to software cursor on failure.
+		 */
 		void setNativeImageCursor(ImagePtr image);
 
 		/** To get some consistancy between platforms, this function checks

--- a/engine/core/video/opengl/glimage.cpp
+++ b/engine/core/video/opengl/glimage.cpp
@@ -500,7 +500,7 @@ namespace FIFE {
 			generateGLSharedTexture(img, region);
 		}
 
-		setState(IResource::RES_LOADED);
+		setState(m_shared_img->getState());
 	}
 
 	void GLImage::forceLoadInternal() {

--- a/engine/core/video/video.i
+++ b/engine/core/video/video.i
@@ -289,6 +289,8 @@ namespace FIFE {
 		uint32_t getY() const;
 		void setPosition(uint32_t x, uint32_t y);
 		void getPosition(int32_t* x, int32_t* y);
+		void setNativeImageCursorEnabled(bool native_image_cursor_enabled);
+		bool isNativeImageCursorEnabled() const;
 
 	private:
 		Cursor();

--- a/engine/python/fife/extensions/basicapplication.py
+++ b/engine/python/fife/extensions/basicapplication.py
@@ -137,6 +137,7 @@ class ApplicationBase(object):
 		engineSetting.setVideoDriver(self._finalSetting['VideoDriver'])
 		engineSetting.setSDLDriver(self._finalSetting['RenderDriver'])
 		engineSetting.setLightingModel(self._finalSetting['Lighting'])
+		engineSetting.setNativeImageCursorEnabled(self._finalSetting['NativeImageCursor'])
 
 		try:
 			engineSetting.setColorKeyEnabled(self._finalSetting['ColorKeyEnabled'])

--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -108,7 +108,8 @@ class Setting(object):
 			'PlaySounds':[True,False], 'LogToFile':[True,False],
 			'LogToPrompt':[True,False], 'LogLevelFilter':[0,1,2,3],
 			'LogModules':['all', 'controller','script','video','audio','loaders','vfs','pool','view','model','metamodel','event_channel','xml'],
-			'FrameLimitEnabled':[True,False], 'FrameLimit':[0], 'MouseSensitivity':[0.0], 'MouseAcceleration':[True,False]
+			'FrameLimitEnabled':[True,False], 'FrameLimit':[0], 'MouseSensitivity':[0.0], 'MouseAcceleration':[True,False],
+			'NativeImageCursor':[True,False]
 			}
 
 		glyphDft = " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?-+/():;%&amp;`'*#=[]\\\""
@@ -128,7 +129,8 @@ class Setting(object):
 			'LogModules':['controller','script'],
 			'FrameLimitEnabled':False, 'FrameLimit':60,
 			'MouseSensitivity':0.0,
-			'MouseAcceleration':False
+			'MouseAcceleration':False,
+			'NativeImageCursor':False
 			}
 
 		# has the settings file been read
@@ -363,6 +365,8 @@ class Setting(object):
 					elif name == "MouseSensitivity":
 						self._settingsFromFile[module][name] = e_value
 					elif name == "MouseAcceleration":
+						self._settingsFromFile[module][name] = e_value
+					elif name == "NativeImageCursor":
 						self._settingsFromFile[module][name] = e_value
 
 					elif name in ("SDLRemoveFakeAlpha", "LogToPrompt", "LogToFile"):


### PR DESCRIPTION
Issue #1012 
This PR adds the native image cursor feature.
If enabled, cursors set to an image or an animation will be set using SDL and drawn by the native platform; otherwise they will be drawn by FIFE.
This setting has no effect on NativeCursor types which are always native and on the drag cursor which is always drawn by FIFE.
Animations are implemented by setting a new SDL cursor whenever the animation frame changes.
If creating the cursor fails we log the error and fall back to software cursor.

Animated cursors work fine when loaded with AnimationLoader, but when I tried to use object animations like this:
```
action = self.application.model.getObject(object_name, "steamfolktales").getAction("idle")
visual = action.get2dGfxVisual()
anim = visual.getAnimationByAngle(visual.getActionImageAngles()[0])
self.application.engine.getCursor().set(anim)
```
creating the cursor failed at first because Image::getSurface() returned NULL. Calling ImageManager::load() beforehand didn't help. But if retried a few times after a few seconds it started working for some reason. Possibly a bug in GLImage?