### PR TITLE
travis give right version back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ matrix:
       sudo: required
       dist: trusty
       compiler: clang
-      python: "3.5"
+      python: "3.4"
     - os: linux
       sudo: required
       dist: trusty
       compiler: gcc
-      python: "3.5"
+      python: "3.4"
     - os: osx
       compiler: clang
     - os: osx
@@ -83,7 +83,7 @@ script:
 
 after_script:
   - cd $TRAVIS_BUILD_DIR
-  - python3 -c 'from fife import fife; print(fife.getVersion())'
+  - python3.4 -c 'import fife; print(fife.getVersion())'
   - if [ $TRAVIS_OS_NAME == linux ]; then cppcheck --verbose --enable=all --std=posix --std=c++11 --quiet -iengine/core/ext engine/core; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then pylint --rcfile=.pylintrc ./engine/python/fife/; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: cpp
-sudo: false
+sudo: true
 matrix:
   include:
     - os: linux
       sudo: required
       dist: trusty
       compiler: clang
-      python: "3.4"
+      python: "3.5"
     - os: linux
       sudo: required
       dist: trusty
       compiler: gcc
-      python: "3.4"
+      python: "3.5"
     - os: osx
       compiler: clang
     - os: osx
@@ -65,27 +65,27 @@ before_install:
   - cmake --version
 
 install:
-    - git clone --quiet --depth 1 git://github.com/fifengine/fifechan.git
-    # https://github.com/fifengine/fifechan/blob/master/INSTALL.md
-    - if [ $TRAVIS_OS_NAME == linux ]; then mkdir build_fifechan; cd build_fifechan; cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ../fifechan; fi
-    - if [ $TRAVIS_OS_NAME == osx ]; then mkdir build_fifechan; cd build_fifechan; cmake ../fifechan; fi
-    - make -j3
-    - sudo make install
-    - cd ..
+  - git clone --quiet --depth 1 git://github.com/fifengine/fifechan.git
+  # https://github.com/fifengine/fifechan/blob/master/INSTALL.md
+  - if [ $TRAVIS_OS_NAME == linux ]; then mkdir build_fifechan; cd build_fifechan; cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr ../fifechan; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then mkdir build_fifechan; cd build_fifechan; cmake ../fifechan; fi
+  - make -j3
+  - sudo make install
+  - cd ..
 
 script:
-   - cd ..
-   - if [ $TRAVIS_OS_NAME == linux ]; then mkdir build; cd build; cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX:PATH=/usr ../fifengine; fi
-   - if [ $TRAVIS_OS_NAME == osx ]; then mkdir build; cd build; cmake -DPYTHON_EXECUTABLE:PATH=/usr/local/bin/python3 -DPYTHON_INCLUDE_DIR=/Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m -DPYTHON_LIBRARY=/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6 ../fifengine; fi
-   - ls -alh .
-   - make -j3
-   - sudo make install
+  - cd ..
+  - if [ $TRAVIS_OS_NAME == linux ]; then mkdir build; cd build; cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -DCMAKE_INSTALL_PREFIX:PATH=/usr ../fifengine; fi
+  - if [ $TRAVIS_OS_NAME == osx ]; then mkdir build; cd build; cmake -DPYTHON_EXECUTABLE:PATH=/usr/local/bin/python3 -DPYTHON_INCLUDE_DIR=/Library/Frameworks/Python.framework/Versions/3.6/include/python3.6m -DPYTHON_LIBRARY=/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6 ../fifengine; fi
+  - ls -alh .
+  - make -j3
+  - sudo make install
 
-after_script: 
-   - cd /home/travis/build/fifengine/fifengine
-   - python3 -c 'from fife import fife; print(fife.getVersion())'
-   - if [ $TRAVIS_OS_NAME == linux ]; then cppcheck --verbose --enable=all --std=posix --std=c++11 --quiet -iengine/core/ext engine/core; fi
-   - if [ $TRAVIS_OS_NAME == linux ]; then pylint --rcfile=.pylintrc ./engine/python/fife/; fi
+after_script:
+  - cd $TRAVIS_BUILD_DIR
+  - python3 -c 'from fife import fife; print(fife.getVersion())'
+  - if [ $TRAVIS_OS_NAME == linux ]; then cppcheck --verbose --enable=all --std=posix --std=c++11 --quiet -iengine/core/ext engine/core; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then pylint --rcfile=.pylintrc ./engine/python/fife/; fi
 
 notifications:
   irc: irc.freenode.org#fife

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
 
 after_script:
   - cd $TRAVIS_BUILD_DIR
-  - python3.4 -c 'import fife; print(fife.getVersion())'
+  - python3.4 -c 'from fife import fife; print(fife.getVersion())'
   - if [ $TRAVIS_OS_NAME == linux ]; then cppcheck --verbose --enable=all --std=posix --std=c++11 --quiet -iengine/core/ext engine/core; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then pylint --rcfile=.pylintrc ./engine/python/fife/; fi
 


### PR DESCRIPTION
now give travis the right version back.
```
$ python3.4 -c 'from fife import fife; print(fife.getVersion())'
0.4.1+build.f276e08
```
I make a lots of tests, the defauft python3 in travis is 3.5. But it was build with 3.4. And thats the reasion why the python3 call can not find fife.
But I try to build with 3.5, that is not working 'cmake' found everytime the 3.4.

