### PR TITLE
Simplify camera

### DIFF
--- a/engine/core/loaders/native/map/maploader.cpp
+++ b/engine/core/loaders/native/map/maploader.cpp
@@ -675,14 +675,13 @@ namespace FIFE {
 
 					for (const TiXmlElement* cameraElement = root->FirstChildElement("camera"); cameraElement; cameraElement = cameraElement->NextSiblingElement("camera")) {
 						const std::string* cameraId = cameraElement->Attribute(std::string("id"));
-						const std::string* refLayerId = cameraElement->Attribute(std::string("ref_layer_id"));
 
 						int refCellWidth = 0;
 						int refCellHeight = 0;
 						int success = cameraElement->QueryIntAttribute("ref_cell_width", &refCellWidth);
 						success &= cameraElement->QueryIntAttribute("ref_cell_height", &refCellHeight);
 
-						if (cameraId && refLayerId && success == TIXML_SUCCESS) {
+						if (cameraId && success == TIXML_SUCCESS) {
 							double tilt = 0.0;
 							double zoom = 1.0;
 							double rotation = 0.0;
@@ -694,47 +693,37 @@ namespace FIFE {
 
 							const std::string* viewport = cameraElement->Attribute(std::string("viewport"));
 
-							Layer* layer = NULL;
-							try {
-								layer = map->getLayer(*refLayerId);
-							}
-							catch (NotFound&) {
-								// TODO - handle exception
-								assert(false);
-							}
-
 							Camera* cam = NULL;
-							if (layer) {
-								if (viewport) {
-									// parse out the viewport parameters
-									IntVector viewportParameters = tokenize(*viewport, ',');
 
-									// make sure the right number of viewport parameters were parsed
-									if (viewportParameters.size() == 4) {
-										Rect rect(viewportParameters[0], viewportParameters[1],
-													viewportParameters[2], viewportParameters[3]);
+							if (viewport) {
+								// parse out the viewport parameters
+								IntVector viewportParameters = tokenize(*viewport, ',');
 
-										try {
-											cam = map->addCamera(*cameraId, layer, rect);
-										}
-										catch (NameClash&) {
-											// TODO - handle exception
-											assert(false);
-										}
-									}
-								}
-								else {
-									Rect rect(0, 0, m_renderBackend->getScreenWidth(), m_renderBackend->getScreenHeight());
+								// make sure the right number of viewport parameters were parsed
+								if (viewportParameters.size() == 4) {
+									Rect rect(viewportParameters[0], viewportParameters[1],
+												viewportParameters[2], viewportParameters[3]);
 
 									try {
-										cam = map->addCamera(*cameraId, layer, rect);
+										cam = map->addCamera(*cameraId, rect);
 									}
 									catch (NameClash&) {
 										// TODO - handle exception
 										assert(false);
 									}
 								}
+							} else {
+								Rect rect(0, 0, m_renderBackend->getScreenWidth(), m_renderBackend->getScreenHeight());
+
+								try {
+									cam = map->addCamera(*cameraId, rect);
+								}
+								catch (NameClash&) {
+									// TODO - handle exception
+									assert(false);
+								}
 							}
+
 
 							if (cam) {
 								cam->setCellImageDimensions(refCellWidth, refCellHeight);

--- a/engine/core/model/structures/map.cpp
+++ b/engine/core/model/structures/map.cpp
@@ -242,18 +242,14 @@ namespace FIFE {
 		}
 	}
 
-	Camera* Map::addCamera(const std::string &id, Layer *layer, const Rect& viewport) {
-		if (layer == NULL) {
-			throw NotSupported("Must have valid layer for camera");
-		}
-
+	Camera* Map::addCamera(const std::string &id, const Rect& viewport) {
 		if (getCamera(id)) {
 			std::string errorStr = "Camera: " + id + " already exists";
 			throw NameClash(errorStr);
 		}
 
 		// create new camera and add to list of cameras
-		Camera* camera = new Camera(id, layer, viewport, m_renderBackend);
+		Camera* camera = new Camera(id, this, viewport, m_renderBackend);
 		m_cameras.push_back(camera);
 
 		std::vector<RendererBase*>::iterator iter = m_renderers.begin();

--- a/engine/core/model/structures/map.h
+++ b/engine/core/model/structures/map.h
@@ -175,7 +175,7 @@ namespace FIFE {
 			/** Adds camera to the map. The Map takes ownership of the camera
 				so don't delete it.
 			*/
-			Camera* addCamera(const std::string& id, Layer *layer, const Rect& viewport);
+			Camera* addCamera(const std::string& id, const Rect& viewport);
 
 			/** Removes a camera from the map
 			*/

--- a/engine/core/model/structures/map.i
+++ b/engine/core/model/structures/map.i
@@ -79,7 +79,7 @@ namespace FIFE {
 			void removeChangeListener(MapChangeListener* listener);
 			bool isChanged();
 			std::vector<Layer*>& getChangedLayers();
-			Camera* addCamera(const std::string& id, Layer *layer, const Rect& viewport);
+			Camera* addCamera(const std::string& id, const Rect& viewport);
 			void removeCamera(const std::string& id);
 			Camera* getCamera(const std::string& id);
 			std::vector<Camera*>& getCameras();

--- a/engine/core/savers/native/map/mapsaver.cpp
+++ b/engine/core/savers/native/map/mapsaver.cpp
@@ -436,12 +436,11 @@ namespace FIFE {
         CameraContainer cameras = map.getCameras();
         for (CameraContainer::iterator iter = cameras.begin(); iter != cameras.end(); ++iter)
         {
-            if ((*iter)->getLocationRef().getMap()->getId() == map.getId())
+            if ((*iter)->getMap()->getId() == map.getId())
             {
                 TiXmlElement* cameraElement = new TiXmlElement("camera");
 
                 cameraElement->SetAttribute("id", (*iter)->getId());
-                cameraElement->SetAttribute("ref_layer_id", (*iter)->getLocation().getLayer()->getId());
                 cameraElement->SetDoubleAttribute("zoom", (*iter)->getZoom());
                 cameraElement->SetDoubleAttribute("tilt", (*iter)->getTilt());
                 cameraElement->SetDoubleAttribute("rotation", (*iter)->getRotation());

--- a/engine/core/view/camera.cpp
+++ b/engine/core/view/camera.cpp
@@ -77,52 +77,53 @@ namespace FIFE {
 		}
 	};
 
-	Camera::Camera(const std::string& id,
-		Layer *layer,
-		const Rect& viewport,
-		RenderBackend* renderbackend):
-			m_id(id),
-			m_matrix(),
-			m_inverse_matrix(),
-			m_tilt(0),
-			m_rotation(0),
-			m_zoom(1),
-			m_zToY(0),
-			m_enabledZToY(false),
-			m_location(),
-			m_cur_origo(ScreenPoint(0,0,0)),
-			m_viewport(),
-			m_mapViewPort(),
-			m_mapViewPortUpdated(false),
-			m_screen_cell_width(1),
-			m_screen_cell_height(1),
-			m_referenceScaleX(1),
-			m_referenceScaleY(1),
-			m_enabled(true),
-			m_attachedto(NULL),
-			m_image_dimensions(),
-			m_transform(NoneTransform),
-			m_renderers(),
-			m_pipeline(),
-			m_updated(false),
-			m_renderbackend(renderbackend),
-			m_layerToInstances(),
-			m_lighting(false),
-			m_light_colors(),
-			m_col_overlay(false),
-			m_img_overlay(false),
-			m_ani_overlay(false) {
-		m_viewport = viewport;
+	Camera::Camera(const std::string& id, Map* map, const Rect& viewport, RenderBackend* renderbackend) :
+		m_id(id),
+		m_map(map),
+		m_viewport(viewport),
+		m_renderbackend(renderbackend),
+		m_position(ExactModelCoordinate(0, 0, 0)),
+		m_matrix(),
+		m_inverse_matrix(),
+		m_tilt(0),
+		m_rotation(0),
+		m_zoom(1),
+		m_zToY(0),
+		m_enabledZToY(false),
+		m_location(),
+		m_curOrigin(ScreenPoint(0, 0, 0)),
+		m_mapViewPort(),
+		m_mapViewPortUpdated(false),
+		m_screenCellWidth(1),
+		m_screenCellHeight(1),
+		m_referenceScaleX(1),
+		m_referenceScaleY(1),
+		m_enabled(true),
+		m_attachedTo(NULL),
+		m_transform(NoneTransform),
+		m_renderers(),
+		m_pipeline(),
+		m_updated(false),
+		m_layerToInstances(),
+		m_lighting(false),
+		m_light_colors(),
+		m_col_overlay(false),
+		m_img_overlay(false),
+		m_ani_overlay(false) {
+
 		m_map_observer = new MapObserver(this);
-		m_map = 0;
-		Location location;
-		location.setLayer(layer);
-		setLocation(location);
+		init();
 	}
 
 	Camera::~Camera() {
 		// Trigger removal of LayerCaches and MapObserver
-		updateMap(NULL);
+		if (m_map) {
+			m_map->removeChangeListener(m_map_observer);
+			const std::list<Layer*>& layers = m_map->getLayers();
+			for (std::list<Layer*>::const_iterator i = layers.begin(); i != layers.end(); ++i) {
+				removeLayer(*i);
+			}
+		}
 
 		std::map<std::string, RendererBase*>::iterator r_it = m_renderers.begin();
 		for(; r_it != m_renderers.end(); ++r_it) {
@@ -131,6 +132,20 @@ namespace FIFE {
 		}
 		m_renderers.clear();
 		delete m_map_observer;
+	}
+
+	void Camera::init() {
+
+		m_transform |= PositionTransform;
+		updateMatrices();
+
+		m_curOrigin = toScreenCoordinates(m_position);
+
+		m_map->addChangeListener(m_map_observer);
+		const std::list<Layer*>& layers = m_map->getLayers();
+		for (std::list<Layer*>::const_iterator i = layers.begin(); i != layers.end(); ++i) {
+			addLayer(*i);
+		}
 	}
 
 	void Camera::setTilt(double tilt) {
@@ -150,6 +165,7 @@ namespace FIFE {
 		if (!Mathd::Equal(m_rotation, rotation)) {
 			m_transform |= RotationTransform;
 			m_rotation = rotation;
+			updateReferenceScale();
 			updateMatrices();
 		}
 	}
@@ -210,81 +226,46 @@ namespace FIFE {
 	}
 
 	void Camera::setCellImageDimensions(uint32_t width, uint32_t height) {
-		m_screen_cell_width = width;
-		m_screen_cell_height = height;
+		m_screenCellWidth = width;
+		m_screenCellHeight = height;
 		updateReferenceScale();
 		updateMatrices();
 		m_transform |= PositionTransform;
 	}
 
 	void Camera::setLocation(const Location& location) {
-		if (m_location == location ) {
+		if (m_location == location) {
 			return;
 		}
 
 		CellGrid* cell_grid = NULL;
 		if (location.getLayer()) {
 			cell_grid = location.getLayer()->getCellGrid();
-		} else {
+			if (!cell_grid) {
+				throw Exception("Location layer without cellgrid given to Camera::setLocation");
+			}
+		}
+		else {
 			throw Exception("Location without layer given to Camera::setLocation");
 		}
-		if (!cell_grid) {
-			throw Exception("Camera layer has no cellgrid specified");
-		}
-		
+
 		m_transform |= PositionTransform;
 		m_location = location;
 		updateMatrices();
 
-		ExactModelCoordinate emc = m_location.getMapCoordinates();
-		m_cur_origo = toScreenCoordinates(emc);
-
-		// WARNING
-		// It is important that m_location is already set,
-		// as the updates which are triggered here
-		// need to calculate screen-coordinates
-		// which depend on m_location.
-		updateMap(m_location.getMap());
-	}
-
-	void Camera::updateMap(Map* map) {
-		if(m_map == map) {
-			return;
-		}
-		if(m_map) {
-			m_map->removeChangeListener(m_map_observer);
-			const std::list<Layer*>& layers = m_map->getLayers();
-			for(std::list<Layer*>::const_iterator i = layers.begin(); i !=layers.end(); ++i) {
-				removeLayer(*i);
-			}
-		}
-		if(map) {
-			map->addChangeListener(m_map_observer);
-			const std::list<Layer*>& layers = map->getLayers();
-			for(std::list<Layer*>::const_iterator i = layers.begin(); i !=layers.end(); ++i) {
-				addLayer(*i);
-			}
-		}
-		m_map = map;
+		m_position = m_location.getMapCoordinates();
+		m_curOrigin = toScreenCoordinates(m_position);
 	}
 
 	Point Camera::getCellImageDimensions() {
-		return getCellImageDimensions(m_location.getLayer());
+		return Point(m_screenCellWidth, m_screenCellHeight);
 	}
 
 	Point Camera::getCellImageDimensions(Layer* layer) {
-		if (layer == m_location.getLayer()) {
-			return Point( m_screen_cell_width, m_screen_cell_height );
-		}
-		std::map<Layer*, Point>::iterator it = m_image_dimensions.find(layer);
-		if (it != m_image_dimensions.end()) {
-			return it->second;
-		}
 		Point p;
 		DoublePoint dimensions = getLogicalCellDimensions(layer);
 		p.x = static_cast<int32_t>(round(m_referenceScaleX * dimensions.x));
 		p.y = static_cast<int32_t>(round(m_referenceScaleY * dimensions.y));
-		m_image_dimensions[layer] = p;
 		return p;
 	}
 
@@ -363,19 +344,15 @@ namespace FIFE {
 	}
 
 	Point3D Camera::getOrigin() const {
-		return m_cur_origo;
+		return m_curOrigin;
 	}
 
 	void Camera::updateMatrices() {
 		m_matrix.loadScale(m_referenceScaleX, m_referenceScaleY, m_referenceScaleX);
 		m_vs_matrix.loadScale(m_referenceScaleX, m_referenceScaleY, m_referenceScaleX);
-		if (m_location.getLayer()) {
-			CellGrid* cg = m_location.getLayer()->getCellGrid();
-			if (cg) {
-				ExactModelCoordinate pt = m_location.getMapCoordinates();
-				m_matrix.applyTranslate(-pt.x*m_referenceScaleX, -pt.y*m_referenceScaleY, -pt.z*m_referenceScaleX);
-			}
-		}
+		
+		m_matrix.applyTranslate(-m_position.x*m_referenceScaleX, -m_position.y*m_referenceScaleY, -m_position.z*m_referenceScaleX);
+
 		m_matrix.applyRotate(-m_rotation, 0.0, 0.0, 1.0);
 		m_matrix.applyRotate(-m_tilt, 1.0, 0.0, 0.0);
 		if (m_enabledZToY) {
@@ -413,7 +390,7 @@ namespace FIFE {
 	}
 
 	void Camera::calculateZValue(DoublePoint3D& screen_coords) {
-		int32_t dy = -(screen_coords.y - toScreenCoordinates(m_location.getMapCoordinates()).y);
+		int32_t dy = -(screen_coords.y - toScreenCoordinates(m_position).y);
 		screen_coords.z = Mathd::Tan(m_tilt * (Mathd::pi() / 180.0)) * static_cast<double>(dy);
 	}
 
@@ -477,50 +454,47 @@ namespace FIFE {
 		return DoublePoint( x2 - x1, y2 - y1 );
 	}
 
-	Point Camera::getRealCellDimensions(Layer* layer) {
-		assert(layer && layer->getCellGrid());
+	DoublePoint Camera::getLogicalCellDimensions() {
+		std::vector<ExactModelCoordinate> vertices;
+		vertices.push_back(ExactModelCoordinate(-0.5, -0.5));
+		vertices.push_back(ExactModelCoordinate(0.5, -0.5));
+		vertices.push_back(ExactModelCoordinate(0.5, 0.5));
+		vertices.push_back(ExactModelCoordinate(-0.5, 0.5));
 
-		Location loc(layer);
-		ModelCoordinate cell(0,0);
-		loc.setLayerCoordinates(cell);
-		ScreenPoint sp1 = toScreenCoordinates(loc.getMapCoordinates());
-		++cell.y;
-		loc.setLayerCoordinates(cell);
-		ScreenPoint sp2 = toScreenCoordinates(loc.getMapCoordinates());
+		DoubleMatrix mtx;
+		mtx.loadRotate(m_rotation, 0.0, 0.0, 1.0);
+		mtx.applyRotate(m_tilt, 1.0, 0.0, 0.0);
 
-		Point p(ABS(sp2.x - sp1.x), ABS(sp2.y - sp1.y));
-		if (p.x == 0) {
-			p.x = 1;
+		double x1 = 0;
+		double x2 = 0;
+		double y1 = 0;
+		double y2 = 0;
+
+		for (uint32_t i = 0; i < vertices.size(); i++) {
+			vertices[i] = mtx * vertices[i];
+			if (i == 0) {
+				x1 = x2 = vertices[0].x;
+				y1 = y2 = vertices[0].y;
+			}
+			else {
+				x1 = std::min(vertices[i].x, x1);
+				x2 = std::max(vertices[i].x, x2);
+				y1 = std::min(vertices[i].y, y1);
+				y2 = std::max(vertices[i].y, y2);
+			}
 		}
-		if (p.y == 0) {
-			p.y = 1;
-		}
-		return p;
-	}
-
-	Point3D Camera::getZOffset(Layer* layer) {
-		assert(layer && layer->getCellGrid());
-
-		Location loc(layer);
-		ModelCoordinate cell(0,0,0);
-		loc.setLayerCoordinates(cell);
-		ScreenPoint sp1 = toScreenCoordinates(loc.getMapCoordinates());
-		++cell.z;
-		loc.setLayerCoordinates(cell);
-		ScreenPoint sp2 = toScreenCoordinates(loc.getMapCoordinates());
-
-		return Point3D(sp2.x - sp1.x, sp2.y - sp1.y, sp2.z - sp1.z);
+		return DoublePoint(x2 - x1, y2 - y1);
 	}
 
 	void Camera::updateReferenceScale() {
-		DoublePoint dim = getLogicalCellDimensions(m_location.getLayer());
-		m_referenceScaleX = static_cast<double>(m_screen_cell_width) / dim.x;
-		m_referenceScaleY = static_cast<double>(m_screen_cell_height) / dim.y;
+		DoublePoint dim = getLogicalCellDimensions();
+		m_referenceScaleX = static_cast<double>(m_screenCellWidth) / dim.x;
+		m_referenceScaleY = static_cast<double>(m_screenCellHeight) / dim.y;
 
 		FL_DBG(_log, "Updating reference scale");
 		FL_DBG(_log, LMsg("   tilt=") << m_tilt << " rot=" << m_rotation);
-		FL_DBG(_log, LMsg("   m_screen_cell_width=") << m_screen_cell_width);
-		FL_DBG(_log, LMsg("   m_screen_cell_height=") << m_screen_cell_height);
+		FL_DBG(_log, LMsg("   m_screenCellWidth=") << m_screenCellWidth);
+		FL_DBG(_log, LMsg("   m_screenCellHeight=") << m_screenCellHeight);
 		FL_DBG(_log, LMsg("   m_referenceScaleX=") << m_referenceScaleX);
 		FL_DBG(_log, LMsg("   m_referenceScaleY=") << m_referenceScaleY);
 	}
@@ -672,36 +646,32 @@ namespace FIFE {
 	}
 
 	void Camera::attach(Instance *instance) {
-		// fail if the layers aren't the same
-		if (m_location.getLayer()->getId() != instance->getLocation().getLayer()->getId()) {
-			FL_WARN(_log, "Tried to attach camera to instance on different layer.");
-			return ;
+		if (instance && instance != m_attachedTo) {
+			m_attachedTo = instance;
 		}
-		m_attachedto = instance;
 	}
 
 	void Camera::detach() {
-		m_attachedto = NULL;
+		m_attachedTo = NULL;
 	}
 
 	void Camera::update() {
-		if (!m_attachedto) {
+		if (!m_attachedTo) {
 			return;
 		}
-		ExactModelCoordinate& old_emc = m_location.getExactLayerCoordinatesRef();
-		ExactModelCoordinate new_emc = m_attachedto->getLocationRef().getExactLayerCoordinates(m_location.getLayer());
-		if (Mathd::Equal(old_emc.x, new_emc.x) && Mathd::Equal(old_emc.y, new_emc.y)) {
+		ExactModelCoordinate pos = m_attachedTo->getLocationRef().getMapCoordinates();
+		if (Mathd::Equal(m_position.x, pos.x) && Mathd::Equal(m_position.y, pos.y)) {
 			return;
 		}
 		m_transform |= PositionTransform;
-		old_emc = new_emc;
+		m_position = pos;
 		updateMatrices();
 	}
 
 	void Camera::refresh() {
 		updateMatrices();
 		m_transform |= RotationTransform;
-		m_cur_origo = toScreenCoordinates(m_location.getMapCoordinates());
+		m_curOrigin = toScreenCoordinates(m_position);
 	}
 
 	void Camera::resetUpdates() {
@@ -960,13 +930,12 @@ namespace FIFE {
 	}
 
 	void Camera::updateRenderLists() {
-		Map* map = m_location.getMap();
-		if (!map) {
+		if (!m_map) {
 			FL_ERR(_log, "No map for camera found");
 			return;
 		}
 
-		const std::list<Layer*>& layers = map->getLayers();
+		const std::list<Layer*>& layers = m_map->getLayers();
 		std::list<Layer*>::const_iterator layer_it = layers.begin();
 		for (;layer_it != layers.end(); ++layer_it) {
 			LayerCache* cache = m_cache[*layer_it];
@@ -986,8 +955,8 @@ namespace FIFE {
 
 	void Camera::render() {
 		updateRenderLists();
-		Map* map = m_location.getMap();
-		if (!map) {
+
+		if (!m_map) {
 			return;
 		}
 
@@ -999,7 +968,7 @@ namespace FIFE {
 			}
 		}
 
-		const std::list<Layer*>& layers = map->getLayers();
+		const std::list<Layer*>& layers = m_map->getLayers();
 		std::list<Layer*>::const_iterator layer_it = layers.begin();
 		for ( ; layer_it != layers.end(); ++layer_it) {
 			// layer with static flag will rendered as one texture

--- a/engine/core/view/camera.h
+++ b/engine/core/view/camera.h
@@ -185,22 +185,26 @@ namespace FIFE {
 		 */
 		void setLocation(const Location& location);
 
-		/** Gets the location camera is rendering
+		/** Gets the location camera is rendering. If no location was set, the camera creates a location.
+		 * The top layer of the map together with current camera position are used for that.
 		 * @return camera location
 		 */
-		Location getLocation() const;
+		Location getLocation();
 
-		/** Gets screen point for the camera location
+		/** Sets map point for the camera
+		 * @param position The camera position on the map
+		 */
+		void setPosition(const ExactModelCoordinate& position);
+
+		/** Gets map point of the camera
+		 * @return The camera position on the map
+		 */
+		ExactModelCoordinate getPosition() const;
+
+		/** Gets screen point of the camera
 		 * @return camera screen point
 		 */
 		Point3D getOrigin() const;
-
-		/** Gets a reference to the camera location
-		 * @note if you change returned location without calling Camera::setLocation(...),
-		 *       remember to call Camera::refresh() (otherwise camera transforms are not updated)
-		 * @return reference to the camera location
-		 */
-		Location& getLocationRef();
 
 		/** Attaches the camera to an instance.
 		 * @param instance Instance to which the camera shall be attached

--- a/engine/core/view/camera.i
+++ b/engine/core/view/camera.i
@@ -61,7 +61,7 @@ namespace FIFE {
 		Rect getLayerViewPort(Layer* layer);
 		void setCellImageDimensions(uint32_t width, uint32_t height);
 		Point getCellImageDimensions();
-		Point3D getZOffset(Layer* layer);
+		Point getCellImageDimensions(Layer* layer);
 		ScreenPoint toScreenCoordinates(const ExactModelCoordinate& map_coords);
 		ExactModelCoordinate toMapCoordinates(ScreenPoint screen_coords, bool z_calculated=true);
 		void setEnabled(bool enabled);

--- a/engine/core/view/camera.i
+++ b/engine/core/view/camera.i
@@ -49,9 +49,10 @@ namespace FIFE {
 		void setZToYEnabled(bool enabled);
 		bool isZToYEnabled() const;
 		void setLocation(Location location);
-		Location getLocation() const;
+		Location getLocation();
+		void setPosition(const ExactModelCoordinate& position);
+		ExactModelCoordinate getPosition() const;
 		Point3D getOrigin() const;
-		Location& getLocationRef();
 		void attach(Instance *instance);
 		void detach();
 		Instance* getAttached() const;

--- a/engine/python/fife/extensions/serializers/xmlmap.py
+++ b/engine/python/fife/extensions/serializers/xmlmap.py
@@ -559,7 +559,6 @@ class XMLMapLoader(object):
 			zoom = camera.get('zoom')
 			tilt = camera.get('tilt')
 			rotation = camera.get('rotation')
-			ref_layer_id = camera.get('ref_layer_id')
 			ref_cell_width = camera.get('ref_cell_width')
 			ref_cell_height = camera.get('ref_cell_height')
 			viewport = camera.get('viewport')
@@ -570,16 +569,15 @@ class XMLMapLoader(object):
 			if not rotation: rotation = 0
 
 			if not _id: self._err('Camera declared without an id.')
-			if not ref_layer_id: self._err(''.join(['Camera ', str(_id), ' declared with no reference layer.']))
 			if not (ref_cell_width and ref_cell_height): self._err(''.join(['Camera ', str(_id), ' declared without reference cell dimensions.']))
 
 			try:
 				if viewport:
-					cam = map.addCamera(str(_id), map.getLayer(str(ref_layer_id)),fife.Rect(*[int(c) for c in viewport.split(',')]))
+					cam = map.addCamera(str(_id), fife.Rect(*[int(c) for c in viewport.split(',')]))
 
 				else:
 					screen = self.engine.getRenderBackend()
-					cam = map.addCamera(str(_id), map.getLayer(str(ref_layer_id)),fife.Rect(0,0,screen.getScreenWidth(),screen.getScreenHeight()))
+					cam = map.addCamera(str(_id), fife.Rect(0,0,screen.getScreenWidth(),screen.getScreenHeight()))
 
 				renderer = fife.InstanceRenderer.getInstance(cam)
 				renderer.activateAllLayers(map)

--- a/engine/python/fife/extensions/serializers/xmlmapsaver.py
+++ b/engine/python/fife/extensions/serializers/xmlmapsaver.py
@@ -348,7 +348,7 @@ class XMLMapSaver(object):
 		cameralist = map.getCameras()
 
 		for cam in cameralist:
-			if cam.getLocationRef().getMap().getId() == map.getId():
+			if cam.getMap().getId() == map.getId():
 				celldimensions = cam.getCellImageDimensions()
 				viewport = cam.getViewPort();
 
@@ -357,7 +357,6 @@ class XMLMapSaver(object):
 						(None, 'zoom'): 'zoom',
 						(None, 'tilt'): 'tile',
 						(None, 'rotation'): 'rotation',
-						(None, 'ref_layer_id'): 'ref_layer_id',
 						(None, 'ref_cell_width'): 'ref_cell_width',
 						(None, 'ref_cell_height'): 'ref_cell_height',
 				}
@@ -367,7 +366,6 @@ class XMLMapSaver(object):
 					(None, 'zoom'): str( cam.getZoom()),
 					(None, 'tilt'): str( cam.getTilt()),
 					(None, 'rotation'): str( cam.getRotation()),
-					(None, 'ref_layer_id'): cam.getLocation().getLayer().getId(),
 					(None, 'ref_cell_width'): str( celldimensions.x ),
 					(None, 'ref_cell_height'): str( celldimensions.y ),
 				}

--- a/tests/swig_tests/action_tests.py
+++ b/tests/swig_tests/action_tests.py
@@ -97,7 +97,7 @@ class ActionTests(unittest.TestCase):
 		rb = self.engine.getRenderBackend()
 		viewport = fife.Rect(0, 0, rb.getWidth(), rb.getHeight())
 		
-		cam = self.map.addCamera("foo", self.layer, viewport)
+		cam = self.map.addCamera("foo", viewport)
 		cam.setCellImageDimensions(self.ground.img.getWidth(), self.ground.img.getHeight())
 		cam.setRotation(45)
 		cam.setTilt(40)

--- a/tests/swig_tests/animation_tests.py
+++ b/tests/swig_tests/animation_tests.py
@@ -75,7 +75,7 @@ class TestView(unittest.TestCase):
 		rb = self.engine.getRenderBackend()
 		viewport = fife.Rect(0, 0, rb.getWidth(), rb.getHeight())
 
-		cam = self.map.addCamera("foo", self.layer, viewport )
+		cam = self.map.addCamera("foo", viewport )
 		cam.setCellImageDimensions(self.screen_cell_w, self.screen_cell_h)
 		cam.setRotation(45)
 		cam.setTilt(40)

--- a/tests/swig_tests/view_tests.py
+++ b/tests/swig_tests/view_tests.py
@@ -62,11 +62,11 @@ class TestView(unittest.TestCase):
 		rb = self.engine.getRenderBackend()
 		viewport = fife.Rect(0, 0, rb.getWidth(), rb.getHeight())
 
-		cam = self.map.addCamera("foo", self.layer, viewport )
+		cam = self.map.addCamera("foo", viewport )
 		cam.setCellImageDimensions(self.screen_cell_w, self.screen_cell_h)
 		cam.setRotation(45)
 		cam.setTilt(40)
-		
+		cam.setLocation(fife.Location(self.layer))
 		cam.setViewPort(viewport)
 		
 		renderer = fife.InstanceRenderer.getInstance(cam)


### PR DESCRIPTION
The PR fix https://github.com/fifengine/fifengine/issues/305
For Clients it is enough to change the reference cell size in case the camera was bound to a layer with a cell grid scale that differs from 1.0. Additionally getLocationRef() from camera is gone.