### PR TITLE
CMakeLists.txt: Use `-undefined dynamic_lookup`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -912,7 +912,12 @@ if(build-python)
     swig_add_module(fife python "${PROJECT_BINARY_DIR}/fife.i" ${FIFE_SOURCES})
   endif(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.7)
 
-  swig_link_libraries(fife ${PYTHON_LIBRARIES})
+  if(APPLE)
+    set(APPLE_DYNAMIC_LOOKUP_FLAG "-undefined dynamic_lookup")
+    swig_link_libraries(fife ${APPLE_DYNAMIC_LOOKUP_FLAG} )
+  else(APPLE)
+    swig_link_libraries(fife ${PYTHON_LIBRARIES})
+  endif(APPLE)
   swig_link_libraries(fife ${SDL2_LIBRARY}
                            ${SDL2_IMAGE_LIBRARIES}
                            ${SDL2_TTF_LIBRARIES}
@@ -939,7 +944,11 @@ if(build-python)
       swig_add_module(fifechan python "${PROJECT_BINARY_DIR}/fifechan.i")
     endif(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.7)
 
-    swig_link_libraries(fifechan ${PYTHON_LIBRARIES})
+    if(APPLE)
+      swig_link_libraries(fifechan ${APPLE_DYNAMIC_LOOKUP_FLAG})
+    else(APPLE)
+      swig_link_libraries(fifechan ${PYTHON_LIBRARIES})
+    endif(APPLE)
     swig_link_libraries(fifechan ${FIFECHAN_LIBRARIES})
     swig_link_libraries(fife ${FIFECHAN_LIBRARIES})
   endif(fifechan)


### PR DESCRIPTION
Python extension modules **should not** link directly to a Python library binary on `macOS`.
They should be linked with "-undefined dynamic_lookup" instead of "-lpython" or "-framework Python" for MacOS.

Adapting same modification to `CMakeLists.txt` of "0.4.1.tar.gz" , "CMakeFiles/_fifechan.dir/link.txt" changed to the following.
>/usr/local/Homebrew/Library/Homebrew/shims/super/clang++ -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -mmacosx-version-min=10.13 -bundle -Wl,-headerpad_max_install_names  -o _fifechan.so CMakeFiles/_fifechan.dir/fifechanPYTHON_wrap.cxx.o  -L/usr/local/lib/libfifechan.dylib  -L/usr/local/lib/libfifechan_sdl.dylib  -L/usr/local/lib/libfifechan_opengl.dylib -Wl,-rpath,/usr/local/lib/libfifechan.dylib -Wl,-rpath,/usr/local/lib/libfifechan_sdl.dylib -Wl,-rpath,/usr/local/lib/libfifechan_opengl.dylib -undefined dynamic_lookup /usr/local/lib/libfifechan.dylib /usr/local/lib/libfifechan_sdl.dylib /usr/local/lib/libfifechan_opengl.dylib 