### PR TITLE
ceguiinputprocessor.h: include SDL.h

### DIFF
--- a/engine/core/gui/cegui/base/ceguiinputprocessor.h
+++ b/engine/core/gui/cegui/base/ceguiinputprocessor.h
@@ -25,7 +25,7 @@
 // Standard C++ library includes
 
 // 3rd party library includes
-#include <SDL_events.h>
+#include <SDL.h>
 
 // FIFE includes
 // These includes are split up in two parts, separated by one empty line


### PR DESCRIPTION
This is fix https://github.com/fifengine/fifengine/issues/1045.