### PR TITLE
fix #1051: fire mouseexit/mouseenter when entering/exiting widgets

### DIFF
--- a/engine/core/eventchannel/eventmanager.h
+++ b/engine/core/eventchannel/eventmanager.h
@@ -272,6 +272,7 @@ namespace FIFE {
 		bool m_acceleration;
 		bool m_warp;
 		bool m_enter;
+		bool m_lastMouseEventConsumed;
 		uint16_t m_oldX;
 		uint16_t m_oldY;
 		uint32_t m_lastTicks;


### PR DESCRIPTION
Before there used to be no way to determine when the mouse was firing mousemoved events to the main view.
Now a mouseexit event is fired when the mouse starts hovering over a widget.
mouseenter events are also added for completeness.