### PR TITLE
MouseEvent.consumedByWidgets is actually called

### DIFF
--- a/engine/core/eventchannel/eventmanager.cpp
+++ b/engine/core/eventchannel/eventmanager.cpp
@@ -152,7 +152,7 @@ namespace FIFE {
 	void EventManager::removeDropListener(IDropListener* listener) {
 		removeListener<IDropListener*>(m_pendingDlDeletions, listener);
 	}
-	
+
 	void EventManager::addJoystickListener(IJoystickListener* listener) {
 		if (m_joystickManager) {
 			m_joystickManager->addJoystickListener(listener);
@@ -718,12 +718,13 @@ namespace FIFE {
 
 		bool consumed = dispatchSdlEvent(event);
 		if (consumed && m_mousefilter) {
+			mouseevt.consumedByWidgets();
 			consumed = !m_mousefilter->isFiltered(mouseevt);
 		}
 		if (consumed) {
 			return;
 		}
-		
+
 		dispatchMouseEvent(mouseevt);
 	}
 


### PR DESCRIPTION
When the mouse event is consumed by any widgets, it is called before firing the event at the fife listeners.
This allows listeners to distinguish between events that were never consumed and consumed events that were let through by the filter.

I did not do this for KeyEvents because they work quite differently in when they are fired.