### PR TITLE
Remove two unneeded lines from cmakelists, 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -836,9 +836,6 @@ if(fifechan)
     )
   endif(build-python)
 
-  include_directories(${FIFECHAN_INCLUDE_DIR})
-  link_directories(${FIFECHAN_LIBRARIES})
-
 endif(fifechan)
 
 if(cegui)  


### PR DESCRIPTION
the second line causing a warning when compiling on OSX.

fixed #1053