### PR TITLE
Remove unsupported command line options to fix compilation on macOS 10.15 (Catalina)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,7 +893,7 @@ if(build-python)
   find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
   include_directories(${PYTHON_INCLUDE_PATH})
 
-  set(CMAKE_SWIG_FLAGS -modern -fastdispatch -dirvtable -nosafecstrings -noproxydel -fastproxy -fastinit -fastunpack -fastquery -modernargs -nobuildnone -keyword -w511 -w473 -w404 -w314)
+  set(CMAKE_SWIG_FLAGS -modern -fastdispatch -dirvtable -noproxydel -fastproxy -fastinit -fastunpack -fastquery -modernargs -keyword -w511 -w473 -w404 -w314)
 
   set_source_files_properties("${PROJECT_BINARY_DIR}/fife.i" PROPERTIES CPLUSPLUS ON)
   set(FIFE_SOURCES ${FIFE_CORE_SRC})


### PR DESCRIPTION
Hi there,
I tried to compile fifengine on macOS Catalina and ran into compilation errors.

I edited CMakeLists.txt and removed
- nosafecstrings
- nobuildnone.

With those changes fifengine builds successfully.