### PR TITLE
Fix build against boost-1.77.0

### DIFF
--- a/engine/core/vfs/zip/zipnode.cpp
+++ b/engine/core/vfs/zip/zipnode.cpp
@@ -28,6 +28,7 @@
 #include "vfs/fife_boost_filesystem.h"
 
 #include "zipnode.h"
+#include <algorithm>
 
 namespace {
     /** helper function to find a value in a ZipNodeContainer


### PR DESCRIPTION
boost-1.77.0 no longer includes `<algorithm>`

Closes: #1080
Signed-off-by: Lars Wendler <polynomial-c@gentoo.org>