### PR TITLE
remove Python2 compatibility

### DIFF
--- a/engine/python/fife/extensions/basicapplication.py
+++ b/engine/python/fife/extensions/basicapplication.py
@@ -26,10 +26,6 @@ The basic application and main loop.
 
 See the L{ApplicationBase} documentation.
 """
-from __future__ import print_function
-
-from builtins import str
-from builtins import object
 from fife import fife
 from fife.extensions import fifelog
 from fife.extensions.fife_settings import Setting

--- a/engine/python/fife/extensions/fife_compat.py
+++ b/engine/python/fife/extensions/fife_compat.py
@@ -36,8 +36,6 @@ run code that wasn't adapted to API changes in FIFE.
  - EventManager.setNonConsumableKeys is superseeded by EventManager.setKeyFilter
 
 """
-from __future__ import print_function
-
 from fife import fife
 
 # Utility functions

--- a/engine/python/fife/extensions/fife_settings.py
+++ b/engine/python/fife/extensions/fife_settings.py
@@ -29,11 +29,6 @@ This module provides a nice framework for loading and saving game settings.
 It is by no means complete but it does provide a good starting point.
 """
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
-from builtins import object
 import shutil
 import os
 from io import StringIO

--- a/engine/python/fife/extensions/fifelog.py
+++ b/engine/python/fife/extensions/fifelog.py
@@ -21,8 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from builtins import object
 from fife import fife
 
 class LogManager(object):

--- a/engine/python/fife/extensions/loaders.py
+++ b/engine/python/fife/extensions/loaders.py
@@ -21,8 +21,6 @@
 # ####################################################################
 
 """ Loaders plugin manager """
-from __future__ import print_function
-
 import os.path
 
 from fife import fife

--- a/engine/python/fife/extensions/pychan/__init__.py
+++ b/engine/python/fife/extensions/pychan/__init__.py
@@ -229,8 +229,6 @@ This leads to a reversed construction sequence as the super classes constructor
 has to be invoked I{after} the subclass specific construction has taken place.
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
 import sys
 
 from builtins import map

--- a/engine/python/fife/extensions/pychan/attrs.py
+++ b/engine/python/fife/extensions/pychan/attrs.py
@@ -40,11 +40,6 @@ This is most useful for error checking parsing and defining
 accepted attributes in classes and is used by pychan internally.
 
 """
-from __future__ import absolute_import
-
-from builtins import map
-from builtins import str
-from builtins import object
 from .exceptions import ParserError
 
 class Attr(object):

--- a/engine/python/fife/extensions/pychan/autoposition.py
+++ b/engine/python/fife/extensions/pychan/autoposition.py
@@ -30,8 +30,6 @@ on top level widgets which can also be set from xml.
 
 For direct use call L{placeWidget}.
 """
-from __future__ import absolute_import
-
 from .internal import screen_width, screen_height
 from .exceptions import PyChanException
 

--- a/engine/python/fife/extensions/pychan/dialog/filebrowser.py
+++ b/engine/python/fife/extensions/pychan/dialog/filebrowser.py
@@ -22,10 +22,6 @@
 # ####################################################################
 
 """ a filebrowser implementation for pychan """
-from __future__ import print_function
-
-from builtins import str
-from builtins import object
 import sys
 import os
 

--- a/engine/python/fife/extensions/pychan/dialogs.py
+++ b/engine/python/fife/extensions/pychan/dialogs.py
@@ -21,12 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import object
 from fife.extensions import pychan
 from fife.extensions.pychan import loadXML
 import fife.extensions.pychan.tools as tools

--- a/engine/python/fife/extensions/pychan/events.py
+++ b/engine/python/fife/extensions/pychan/events.py
@@ -58,13 +58,6 @@ Available Events
 ----------------
 
 """
-from __future__ import print_function
-from __future__ import absolute_import
-
-from builtins import str
-from builtins import range
-from builtins import object
-from future.utils import itervalues
 from .compat import fifechan
 
 from . import exceptions
@@ -184,7 +177,7 @@ class EventListenerBase(object):
 			event = self.translateEvent(getEventType(name), event)
 			if name in self.events:
 				if self.debug: print("-"*self.indent, name)
-				for f in itervalues(self.events[name]):
+				for f in self.events[name].values():
 					if not self._redirect:
 						f(event)
 						continue

--- a/engine/python/fife/extensions/pychan/fife_pychansettings.py
+++ b/engine/python/fife/extensions/pychan/fife_pychansettings.py
@@ -29,9 +29,6 @@ This module provides gui window that sets basic fife settings through
 pychan.
 """
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 import os
 from io import BytesIO, StringIO, StringIO
 

--- a/engine/python/fife/extensions/pychan/fonts.py
+++ b/engine/python/fife/extensions/pychan/fonts.py
@@ -22,11 +22,6 @@
 # ####################################################################
 
 # Font handling
-from __future__ import absolute_import
-from future import standard_library
-standard_library.install_aliases()
-from builtins import map
-from builtins import object
 import os.path
 from .exceptions import *
 from .fontfileparser import FontFileParser

--- a/engine/python/fife/extensions/pychan/internal.py
+++ b/engine/python/fife/extensions/pychan/internal.py
@@ -21,10 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import str
-from builtins import map
-from builtins import object
 from .compat import fifechan, fife, in_fife
 from fife.extensions import fife_timer as timer
 from . import fonts

--- a/engine/python/fife/extensions/pychan/properties.py
+++ b/engine/python/fife/extensions/pychan/properties.py
@@ -21,9 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import object
-from builtins import str as new_str
 from fife import fife, fifechan
 from .exceptions import RuntimeError
 
@@ -87,7 +84,7 @@ class ImageProperty(WrappedProperty):
 			image_info["image"]._source = ""
 			self._getSetter(obj)(None)
 
-		elif isinstance(image, (str, new_str)):
+		elif isinstance(image, str):
 			image_info["source"] = image
 			# to catch or not to catch ...
 			# we just let the NotFound exception trickle here.

--- a/engine/python/fife/extensions/pychan/tools.py
+++ b/engine/python/fife/extensions/pychan/tools.py
@@ -24,9 +24,6 @@
 """
 Functional utilities designed for pychan use cases.
 """
-from __future__ import print_function
-from __future__ import absolute_import
-
 import sys
 
 from builtins import range

--- a/engine/python/fife/extensions/pychan/widgets/__init__.py
+++ b/engine/python/fife/extensions/pychan/widgets/__init__.py
@@ -28,8 +28,6 @@ Widget wrappers.
 
 Please look at the documentation of L{Widget} for details.
 """
-from __future__ import absolute_import
-
 from .widget import Widget
 
 from .spacer import Spacer

--- a/engine/python/fife/extensions/pychan/widgets/adjustingcontainer.py
+++ b/engine/python/fife/extensions/pychan/widgets/adjustingcontainer.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/animationicon.py
+++ b/engine/python/fife/extensions/pychan/widgets/animationicon.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/bargraph.py
+++ b/engine/python/fife/extensions/pychan/widgets/bargraph.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import BoolAttr, ColorAttr, IntAttr, PointAttr

--- a/engine/python/fife/extensions/pychan/widgets/basictextwidget.py
+++ b/engine/python/fife/extensions/pychan/widgets/basictextwidget.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife.extensions.pychan.attrs import UnicodeAttr
 
 from .common import gui2text, text2gui

--- a/engine/python/fife/extensions/pychan/widgets/buttons.py
+++ b/engine/python/fife/extensions/pychan/widgets/buttons.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import Attr, BoolAttr, PointAttr, IntAttr

--- a/engine/python/fife/extensions/pychan/widgets/checkbox.py
+++ b/engine/python/fife/extensions/pychan/widgets/checkbox.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import Attr, BoolAttr, IntAttr

--- a/engine/python/fife/extensions/pychan/widgets/common.py
+++ b/engine/python/fife/extensions/pychan/widgets/common.py
@@ -21,9 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import str
 from fife import fife
 from fife import fifechan
 from fife.extensions.pychan import tools

--- a/engine/python/fife/extensions/pychan/widgets/containers.py
+++ b/engine/python/fife/extensions/pychan/widgets/containers.py
@@ -21,10 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import map
-from builtins import str
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/curvegraph.py
+++ b/engine/python/fife/extensions/pychan/widgets/curvegraph.py
@@ -21,8 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import BoolAttr, ColorAttr, IntAttr, IntListAttr

--- a/engine/python/fife/extensions/pychan/widgets/dockarea.py
+++ b/engine/python/fife/extensions/pychan/widgets/dockarea.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/dropdown.py
+++ b/engine/python/fife/extensions/pychan/widgets/dropdown.py
@@ -21,9 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import map
-from builtins import range
 from fife import fifechan
 
 from .common import text2gui

--- a/engine/python/fife/extensions/pychan/widgets/flowcontainer.py
+++ b/engine/python/fife/extensions/pychan/widgets/flowcontainer.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/icon.py
+++ b/engine/python/fife/extensions/pychan/widgets/icon.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import Attr, BoolAttr

--- a/engine/python/fife/extensions/pychan/widgets/iconprogressbar.py
+++ b/engine/python/fife/extensions/pychan/widgets/iconprogressbar.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.properties import ImageProperty

--- a/engine/python/fife/extensions/pychan/widgets/imageprogressbar.py
+++ b/engine/python/fife/extensions/pychan/widgets/imageprogressbar.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.properties import ImageProperty

--- a/engine/python/fife/extensions/pychan/widgets/label.py
+++ b/engine/python/fife/extensions/pychan/widgets/label.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import BoolAttr

--- a/engine/python/fife/extensions/pychan/widgets/linegraph.py
+++ b/engine/python/fife/extensions/pychan/widgets/linegraph.py
@@ -21,8 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import BoolAttr, ColorAttr, IntAttr, IntListAttr

--- a/engine/python/fife/extensions/pychan/widgets/listbox.py
+++ b/engine/python/fife/extensions/pychan/widgets/listbox.py
@@ -21,10 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import str
-from builtins import map
-from builtins import range
 from fife import fifechan
 
 from .common import gui2str, text2gui

--- a/engine/python/fife/extensions/pychan/widgets/panel.py
+++ b/engine/python/fife/extensions/pychan/widgets/panel.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 import weakref
 from fife import fife
 from fife import fifechan

--- a/engine/python/fife/extensions/pychan/widgets/passwordfield.py
+++ b/engine/python/fife/extensions/pychan/widgets/passwordfield.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import UnicodeAttr

--- a/engine/python/fife/extensions/pychan/widgets/percentagebar.py
+++ b/engine/python/fife/extensions/pychan/widgets/percentagebar.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import IntAttr

--- a/engine/python/fife/extensions/pychan/widgets/piegraph.py
+++ b/engine/python/fife/extensions/pychan/widgets/piegraph.py
@@ -21,9 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
-from builtins import object
 import weakref
 from fife import fifechan
 from fife.extensions.pychan.attrs import BoolAttr, IntAttr, PointAttr, MixedListAttr

--- a/engine/python/fife/extensions/pychan/widgets/pointgraph.py
+++ b/engine/python/fife/extensions/pychan/widgets/pointgraph.py
@@ -21,8 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import BoolAttr, ColorAttr, IntAttr, IntListAttr

--- a/engine/python/fife/extensions/pychan/widgets/radiobutton.py
+++ b/engine/python/fife/extensions/pychan/widgets/radiobutton.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import Attr, BoolAttr

--- a/engine/python/fife/extensions/pychan/widgets/resizablewindow.py
+++ b/engine/python/fife/extensions/pychan/widgets/resizablewindow.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/scrollarea.py
+++ b/engine/python/fife/extensions/pychan/widgets/scrollarea.py
@@ -21,8 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import str
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import BoolAttr, IntAttr

--- a/engine/python/fife/extensions/pychan/widgets/slider.py
+++ b/engine/python/fife/extensions/pychan/widgets/slider.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import IntAttr, FloatAttr

--- a/engine/python/fife/extensions/pychan/widgets/spacer.py
+++ b/engine/python/fife/extensions/pychan/widgets/spacer.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from .widget import Widget

--- a/engine/python/fife/extensions/pychan/widgets/tabbedarea.py
+++ b/engine/python/fife/extensions/pychan/widgets/tabbedarea.py
@@ -21,8 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import str
 from fife import fife
 from fife import fifechan
 

--- a/engine/python/fife/extensions/pychan/widgets/textbox.py
+++ b/engine/python/fife/extensions/pychan/widgets/textbox.py
@@ -21,10 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import str
-from builtins import map
-from builtins import range
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import Attr, UnicodeAttr

--- a/engine/python/fife/extensions/pychan/widgets/textfield.py
+++ b/engine/python/fife/extensions/pychan/widgets/textfield.py
@@ -21,7 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from fife import fifechan
 
 from fife.extensions.pychan.attrs import UnicodeAttr

--- a/engine/python/fife/extensions/pychan/widgets/widget.py
+++ b/engine/python/fife/extensions/pychan/widgets/widget.py
@@ -21,10 +21,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import str
-from builtins import object
 import weakref
 
 from fife import fife

--- a/engine/python/fife/extensions/pythonize.py
+++ b/engine/python/fife/extensions/pythonize.py
@@ -39,9 +39,6 @@ conveniences:
     - fife.Point
     - fife.Rect
 """
-from __future__ import print_function
-
-from builtins import map
 from fife import fife
 from fife import fifechan
 import re

--- a/engine/python/fife/extensions/savers.py
+++ b/engine/python/fife/extensions/savers.py
@@ -21,8 +21,6 @@
 # ####################################################################
 
 """ Savers plugin manager  """
-from __future__ import print_function
-
 import os.path
 
 from fife import fife

--- a/engine/python/fife/extensions/serializers/__init__.py
+++ b/engine/python/fife/extensions/serializers/__init__.py
@@ -20,8 +20,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from builtins import range
 import fife, sys, os
 from traceback import print_exc
 

--- a/engine/python/fife/extensions/serializers/simplexml.py
+++ b/engine/python/fife/extensions/serializers/simplexml.py
@@ -21,11 +21,7 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
 from past.builtins import basestring
-from builtins import object
 import os
 from io import BytesIO, StringIO
 	

--- a/engine/python/fife/extensions/serializers/xml_loader_tools.py
+++ b/engine/python/fife/extensions/serializers/xml_loader_tools.py
@@ -21,10 +21,6 @@
 # ####################################################################
 
 """ utilities for xml maploading process """
-from __future__ import print_function
-from __future__ import division
-
-from builtins import range
 from past.utils import old_div
 import os
 import math

--- a/engine/python/fife/extensions/serializers/xmlmap.py
+++ b/engine/python/fife/extensions/serializers/xmlmap.py
@@ -21,10 +21,6 @@
 # ####################################################################
 
 """ main xml parser class for xml map loading """
-from __future__ import print_function
-
-from builtins import str
-from builtins import object
 import time
 
 from fife import fife

--- a/engine/python/fife/extensions/serializers/xmlobject.py
+++ b/engine/python/fife/extensions/serializers/xmlobject.py
@@ -21,10 +21,6 @@
 # ####################################################################
 
 """ submodule for xml map parsing """
-from __future__ import print_function
-
-from builtins import str
-from builtins import object
 from fife import fife
 
 from fife.extensions.serializers import ET

--- a/run_tests.py
+++ b/run_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from builtins import input
 import os, re, sys, optparse, unittest
 
 def genpath(somepath):

--- a/tests/fife_test/run.py
+++ b/tests/fife_test/run.py
@@ -23,7 +23,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
 import os
 import sys
 

--- a/tests/fife_test/scripts/fife_test.py
+++ b/tests/fife_test/scripts/fife_test.py
@@ -23,8 +23,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
 import sys, os, re, math, random, shutil, time
 from datetime import datetime
 

--- a/tests/fife_test/scripts/test.py
+++ b/tests/fife_test/scripts/test.py
@@ -23,8 +23,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from builtins import object
 import os
 
 class TestManager(object):

--- a/tests/fife_test/tests/OverlayTest.py
+++ b/tests/fife_test/tests/OverlayTest.py
@@ -23,9 +23,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from builtins import str
-from builtins import range
 from fife import fife
 from fife.extensions import pychan
 

--- a/tests/fife_test/tests/SelectionTest.py
+++ b/tests/fife_test/tests/SelectionTest.py
@@ -23,7 +23,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
 from fife import fife
 from fife.extensions import pychan
 from fife.extensions.pychan.tools import callbackWithArguments as cbwa

--- a/tests/fife_test/tests/TriggerTest.py
+++ b/tests/fife_test/tests/TriggerTest.py
@@ -23,7 +23,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
 from fife import fife
 from fife.extensions import pychan
 from fife.extensions.pychan.tools import callbackWithArguments as cbwa

--- a/tests/swig_tests/action_tests.py
+++ b/tests/swig_tests/action_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 from fife.extensions.serializers.xmlanimation import loadXMLAnimation
 

--- a/tests/swig_tests/animation_tests.py
+++ b/tests/swig_tests/animation_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 import time
 

--- a/tests/swig_tests/audio_tests.py
+++ b/tests/swig_tests/audio_tests.py
@@ -22,7 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 import time
 from .swig_test_utils import *
 from fife.extensions import fifelog

--- a/tests/swig_tests/controller_tests.py
+++ b/tests/swig_tests/controller_tests.py
@@ -22,9 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 
 class TestController(unittest.TestCase):

--- a/tests/swig_tests/cursor_tests.py
+++ b/tests/swig_tests/cursor_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 import time
 

--- a/tests/swig_tests/eventchannel_tests.py
+++ b/tests/swig_tests/eventchannel_tests.py
@@ -22,9 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 
 class MyEventListener(fife.ICommandListener):

--- a/tests/swig_tests/gui_tests.py
+++ b/tests/swig_tests/gui_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 
 class TestGui(unittest.TestCase):

--- a/tests/swig_tests/location_tests.py
+++ b/tests/swig_tests/location_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
 from .swig_test_utils import *
 
 P = fife.ModelCoordinate

--- a/tests/swig_tests/log_tests.py
+++ b/tests/swig_tests/log_tests.py
@@ -22,7 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from .swig_test_utils import *
 
 class TestLog(unittest.TestCase):

--- a/tests/swig_tests/model_tests.py
+++ b/tests/swig_tests/model_tests.py
@@ -22,7 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from .swig_test_utils import *
 import math
 

--- a/tests/swig_tests/resource_tests.py
+++ b/tests/swig_tests/resource_tests.py
@@ -22,7 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 import sys
 from .swig_test_utils import *
 

--- a/tests/swig_tests/swig_test_utils.py
+++ b/tests/swig_tests/swig_test_utils.py
@@ -22,7 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
 import os, sys, unittest
 
 fife_path = os.path.join('..','..','engine','python')

--- a/tests/swig_tests/timer_tests.py
+++ b/tests/swig_tests/timer_tests.py
@@ -22,9 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import range
 from .swig_test_utils import *
 import time
 

--- a/tests/swig_tests/vfs_tests.py
+++ b/tests/swig_tests/vfs_tests.py
@@ -22,8 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
 from .swig_test_utils import *
 
 import sys

--- a/tests/swig_tests/video_tests.py
+++ b/tests/swig_tests/video_tests.py
@@ -22,7 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import absolute_import
 from builtins import range
 from .swig_test_utils import *
 

--- a/tests/swig_tests/view_tests.py
+++ b/tests/swig_tests/view_tests.py
@@ -22,10 +22,6 @@
 #  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 # ####################################################################
 
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import str
-from builtins import range
 from .swig_test_utils import *
 import time
 


### PR DESCRIPTION
Hi,

the `future` library was broken for a long time & has been removed from most distributions this year

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1089510